### PR TITLE
p.71

### DIFF
--- a/fiachra.ttl
+++ b/fiachra.ttl
@@ -2093,7 +2093,6 @@
 <#Flann-6b89a4f0>
 	a foaf:Person;
 	foaf:name "Flann";
-	rdf:value: "Dun Eoghain";
 	owl:sameAs <#Flann-871e0f10>.
 	#<#Flann-871e0f10>, Flann son of Conchobhar, is the most recent identifiable Flann.
 
@@ -2254,4 +2253,182 @@
 <#Flann-1fc75b10>
 	a foaf:Person;
 	foaf:name "Flann";
-	rel:chilfOf <#GiollaNaNaomh-476b36a0>.
+	rel:childOf <#GiollaNaNaomh-476b36a0>.
+
+<#GiollaNaNaomh-476b36a0>
+	a foaf:Person;
+	foaf:name "Giolla na Naomh";
+	rel:childOf <#Cugaela-de49c480>.
+	# Is this <#GiollaNaNaomh-6639d17e>? - ET
+	# This feels like a variant pedigree to that ending on p.69; 
+	# O'Donovan (p.69) notes that it is from the 'Ó Cléirigh
+	# Book of Genealogies'. I'll label the relevant entries "# OCBG" - ET
+
+<#Cugaela-de49c480>
+	a foaf:Person;
+	foaf:name "Cugaela";
+	rel:childOf <#GiollaCheallaigh-062a5af0>. 
+	# OCBG - ET
+
+<#GiollaCheallaigh-062a5af0>
+	a foaf:Person;
+	foaf:name "Giolla Cheallaigh";
+	rel:childOf <#Comaltan-0af9c7e0>;
+	rdfs:comment "from whom the surname is called";
+	owl:sameAs <#GiollaCheallaigh-9ae865a0>.
+	# OCBG - ET
+	# Is the added comment sufficient to warrant 
+	# rel:ancestorOf "Meic Giolla Cheallaigh"?
+
+<#Comaltan-0af9c7e0>
+	a foaf:Person;
+	foaf:name "Comaltan";
+	rel:childOf <#Flann-2103d780>;
+	owl:sameAs <#Comaltan>.	
+	# OCBG - ET
+
+<#Flann-2103d780>
+	a foaf:Person;
+	foaf:name "Flann"
+	rel:childOf <#Maelfabhaill-55922060>;
+	rdfs:comment "i.e. Maelcearard";
+	owl:sameAs <#MaolChulaird-6bb045e0>.
+	# OCBG - ET
+
+<#Maelfabhaill-55922060>
+	a foaf:Person;
+	foaf:name "Mael Fabhaill";
+	rel:childOf <#Cleireach-a1d6a9a0>;	
+	owl:sameAs <#Maolfhabhail-8f3bb300>.
+	# OCBG - ET
+
+<#Cleireach-a1d6a9a0>
+	a foaf:Person;
+	foaf:name "Cleireach";
+	rel:childOf <#Ceadadhach-618a21f0>;
+	rel:ancestorOf "the O'Clerys";
+	owl:sameAs <#Clereach>.
+	# OCBG - ET
+
+<#Ceadadhach-618a21f0>
+	a foaf:Person;
+	foaf:name "Ceadadhach";
+	rel:childOf <#Cumasgach-cad05bc0>;
+	owl:sameAs <#Ceadadhach>.
+	# OCBG - ET
+
+<#Cumasgach-cad05bc0>
+	a foaf:Person;
+	foaf:name "Cumasgach";
+	rel:childOf <#Cathmogh-10f24eb0>;
+	owl:sameAs <#Cumascach>.	
+	# OCBG - ET
+
+<#Cathmogh-10f24eb0>
+	a foaf:Person;
+	foaf:name "Cathmogh";
+	rel:childOf <#Torptha-36a0e9f0>;
+	owl:sameAs <#Cathmogha>.
+	# OCBG - ET
+
+<#Torptha-36a0e9f0>
+	a foaf:Person;
+	foaf:name "Torptha";
+	rel:childOf <#Feargal-e659f5d0>;
+	owl:sameAs <#Torpa-7bdf6500>.
+	# OCBG - ET
+
+<#Feargal-e659f5d0>
+	a foaf:Person;
+	foaf:name "Feargal";
+	rel:childOf <#Artgal-1fa50370>;
+	owl:sameAs <#Feargal-b34d7540>.
+	# OCBG - ET
+
+<#Artgal-1fa50370>
+	a foaf:Person;
+	foaf:name "Artgal";
+	rel:childOf <#GuaireAidhne-baa35bb0>;	
+	owl:sameAs <#Artghal>.
+
+<#GuaireAidhne-baa35bb0>
+	a foaf:Person;
+	foaf:name "Guaire Aidhne";
+	owl:sameAs <#GuaireAidhne>.
+	# OCBG - ET
+	# Here ends the extract from OCBG - ET
+
+<#Flann-2d5c4460>
+	a foaf:Person;
+	foaf:name "Flann";
+	rel:childOf <#Lonan>.
+
+<#Lonan>
+	a foaf:Person;
+	foaf:name "Lonan";
+	rel:childOf <#Conmach>.
+
+<#Conmach>
+	a foaf:Person;
+	foaf:name "Conmach";
+	rel:childOf <#Caithniadh>.
+
+<#Caithniadh>
+	a foaf:Person;
+	foaf:name "Caithniadh";
+	rel:childOf <#Aodh-fef61aa0>.
+
+<#Aodh-fef61aa0>
+	a foaf:Person;
+	foaf:name "Aodh";
+	rel:childOf <#Torpa-3cdecc40>.
+	
+<#Torpa-3cdecc40>
+	a foaf:Person;
+	foaf:name "Torpa";
+	rel:childOf <#Feargal-6a8fe160>;
+	owl:sameAs <#Torpa-7bdf6500>.
+
+<#Feargal-6a8fe160>
+	a foaf:Person;
+	foaf:name "Feargal";
+	rel:childOf <#Artgal-a294da70>;
+	owl:sameAs <#Feargal-b34d7540>.
+
+<#Artgal-a294da70>
+	a foaf:Person;
+	foaf:name "Artgal";
+	rel:childOf <#GuaireAidhne-c675e1a0>;
+	owl:sameAs <#Artghal>.
+
+<#GuaireAidhne-c675e1a0>
+	a foaf:Person;
+	foaf:name "Guaire Aidhne";
+	owl:sameAs <#GuaireAidhne>.
+
+<#Artgal-107d7330>
+	a foaf:Person;
+	foaf:name "Artgal";
+	rel:childOf <#Flaithniadh>.
+
+<#Flaithniadh>
+	a foaf:Person;
+	foaf:name "Flaithniadh";
+	rel:childOf <#Feargal-5a7a5660>.
+
+<#Feargal-5a7a5660>
+	a foaf:Person;
+	foaf:name "Feargal";
+	rel:childOf <#Artgal-7dea9a60>;
+	owl:sameAs <#Feargal-b34d7540>.
+
+<#Artgal-7dea9a60>
+	a foaf:Person;
+	foaf:name "Artgal";
+	rel:childOf <#GuaireAidhne-cffc46f0>;
+	owl:sameAs <#Artghal>.
+
+<#GuaireAidhne-cffc46f0>
+	a foaf:Person;
+	foaf:name "Guaire Aidhne";
+	owl:sameAs <#GuaireAidhne>.


### PR DESCRIPTION
This section contains material from the Ó Cléirigh Book of Genealogies
(OCBG). On one level, this is very interesting, as it will allow us to
compare different versions of the same pedigree. However, I am not
actually sure whether Mac Firbisigh himself added it or whether it was
added by O'Donovan (if it is O'Donovan's addition, presumably we omit
it?). He describes the material thus: "This line of Mac Giolla
Cheallaigh's pedigree is inserted from the genealogical MS. in the
handwriting of Peregrine O'Clery, now preserved in the Library of the
Royal Irish Academy; it comes down seven generations later than the line
given by Mac Firbis" (can I respectfully point out that this kind of
confusion becomes inevitable when scholars feel unable to use the
first-person in academic writing? :-P).

The prose paragraph at the foot of p.71 was definitely added by
O'Donovan from OCBG: "All this matter enclosed in brackets, down to the
end of the pedigree of the O'Clerys, has been inserted from Peregrine
O'Clery's genealogical MS now deposited in the Library of the Royal
Irish Academy. Mac Firbis has omitted this family altogether, but, as it
appears from the authentic Irish Annals that they had supplied many
distinguished chiefs to the territory of Hy-Fiachrach Aidhne, the
Editor, deeming it a pity that they should not have their place among
the families of the race of Guaire Aidhne here treated of, has taken the
liberty to lay before the reader the account which this family have
written of themselves".

I can go and check Ó Muraíle's edition for clarification. Or we could
even look out the original ms. on microfilm, since it is in the RIA...