### PR TITLE
Minor corrections to Finn records in DF files

### DIFF
--- a/Duanaire_Finn/PoemXI.ttl
+++ b/Duanaire_Finn/PoemXI.ttl
@@ -103,8 +103,7 @@
 
 <#Finn>
     a foaf:Person;
-    irishRel:nomName "Finn";
-    owl:sameAs <#FiondFile>.
+    irishRel:nomName "Finn".
 
 <#Fearghus>
     a foaf:Person;

--- a/Duanaire_Finn/PoemXLIII.ttl
+++ b/Duanaire_Finn/PoemXLIII.ttl
@@ -601,6 +601,8 @@
       rel:parentOf <#Dáolgus-ef2c8830>, <#Lodharn>
     ].
 
+# NB: Not Finn mac Cumaill. EPT
+
 <#Cúain>
     a foaf:Person;
     irishRel:genName "Cúain";


### PR DESCRIPTION
I was unable to find any instances where Finn mac Cumaill is lacking an owl:sameAs link. In one case, Finn mac Cúain lacks a link but that is because he isn't Finn mac Cumaill. I also concluded while reviewing the files that Fionn File, from Poem XI, is not Finn mac Cumaill (could he be Find File, son of Ross Ruad, whom we encountered in LL/Rawl.B.502 and who is attributed some of the cited poetry therein?). So I have removed the owl:sameAs link from his record. 