### PR TITLE
Data from Siaburcharpat Con Culaind

### DIFF
--- a/LU/siaburcharpat_con_culaind.trig
+++ b/LU/siaburcharpat_con_culaind.trig
@@ -17,5 +17,113 @@
     dcterms:format "text/turtle" ;
     prov:asDerivedFrom <http://www.ucc.ie/celt/published/G301900/text025.html> .
 
+<#Loegairi>
+    a foaf:Person;
+    irishRel:genName "Loegairi";
+    irishRel:nomName "Loegaire";
+    rel:childOf <#Neill>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_ceníuil_loígaire.trig#Lóegaire>.
+
+<#Neill>
+    a foaf:Person;
+    irishRel:genName "Neill";
+    irishRel:nomName "Níall";
+    rel:childOf <#EchachMugmedóin>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_ceníuil_loígaire.trig#NéillNoígiallaig>.
+
+<#EchachMugmedóin>
+    a foaf:Person;
+    irishRel:genName "Echach Mugmedóin";
+    irishRel:nomName "Eochu Mugmedón";
+    rel:childOf <#MuredigTírig>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#EchachMugmedóin>.
+
+<#MuredigTírig>
+    a foaf:Person;
+    irishRel:genName "Muredig Tírig";
+    irishRel:nomName "Muiredach Tírech";
+    rel:childOf <#FiacrachRoptine>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#MuridaigTirig>.
+
+<#FiacrachRoptine>
+    a foaf:Person;
+    irishRel:genName "Fiacrach Roptine";
+    rel:childOf <#CorpriLiphechair>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FhiachachSraptini>.
+
+<#CorpriLiphechair>
+    a foaf:Person;
+    irishRel:genName "Corpri Liphechair";
+    irishRel:nomName "Coirpre Lifechair";
+    rel:childOf <#CormaicUlfotai>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CarpriLiphechair>.
+
+<#CormaicUlfotai>
+    a foaf:Person;
+    irishRel:genName "Cormaic Ulfotai";
+    irishRel:nomName "Cormac Ulfota";
+    rel:childOf <#AirtÓenfir>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CormaicUlfhota>.
+
+<#AirtÓenfir>
+    a foaf:Person;
+    irishRel:genName "Airt Óenfir";
+    irishRel:nomName "Art Óenfer";
+    rel:childOf <#CuindCetchathaig>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#ArtOenfhir>.
+
+<#CuindCetchathaig>
+    a foaf:Person;
+    irishRel:genName "Cuind Cetchathaig";
+    irishRel:nomName "Conn Cetcathach";
+    rel:childOf <#FedelmtheRechtada>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CuindCetchathaig>.
+
+<#FedelmtheRechtada>
+    a foaf:Person;
+    irishRel:genName "Fedelmthe Rechtada";
+    irishRel:nomName "Feidlimid Rechtada";
+    rel:childOf <#TuathailTechtmair>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FheidlimidRechtada>.
+
+<#TuathailTechtmair>
+    a foaf:Person;
+    irishRel:genName "Tuathail Techtmair";
+    irishRel:nomName "Tuathal Techtmar";
+    rel:childOf <#FeradaigFindFechtnaig>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#TuathailTectmair>.
+
+<#FeradaigFindFechtnaig>
+    a foaf:Person;
+    irishRel:genName "Feradaig Find Fechtnaig";
+    irishRel:nomName "Feradach Find Fechtnach";
+    rel:childOf <#CrimtaindNiadNair>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FheradaichFindFechtnaig>.
+
+<#CrimtaindNiadNair>
+    a foaf:Person;
+    irishRel:genName "Crimthand Niad Nair";
+    irishRel:nomName "Crimthand Niad Nair";
+    rel:childOf <#LugdachRiabnDerg>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CrimthaindNiadNaire>.
+
+<#LugdachRiabnDerg>
+    a foaf:Person;
+    irishRel:genName "Lugdach Riab nDerg";
+    irishRel:nomName "Lugaid Riab nDerg";
+    irishRel:fosterChildOf <#ChoinChulaind>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#LugdachRiabn-Derg>.
+
+<#ChoinChulaind>
+    a foaf:Person;
+    irishRel:datName "Choin Chulaind";
+    irishRel:nameName "Cú Culaind";
+    rel:childOf <#Soalda>;
+    owl:sameAs <http://example.com/LU/de_genelogia_con_culaind.trig#CúCulaind>.
+
+<#Soalda>
+    a foaf:Person;
+    irishRel:genName "Soalda";
+    owl:sameAs <http://example.com/LU/de_genelogia_con_culaind.trig#Soaldaim>.
 
 }

--- a/LU/siaburcharpat_con_culaind.trig
+++ b/LU/siaburcharpat_con_culaind.trig
@@ -14,7 +14,7 @@
     a dctype:Dataset;
     dcterms:title "Siaburcharpat Con Culaind"@sga;
     dcterms:isFormatOf <http://www.ucc.ie/celt/published/G301900/text025.html>;
-    dcterms:format "text/turtle" ;
+    dcterms:format "application/trig" ;
     prov:asDerivedFrom <http://www.ucc.ie/celt/published/G301900/text025.html> .
 
 <#Loegairi>

--- a/LU/siaburcharpat_con_culaind.trig
+++ b/LU/siaburcharpat_con_culaind.trig
@@ -1,0 +1,21 @@
+@base <http://example.com/LU/siaburcharpat_con_culaind.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+<http://example.com/LU> {
+<>
+    a dctype:Dataset;
+    dcterms:title "Siaburcharpat Con Culaind"@sga;
+    dcterms:isFormatOf <http://www.ucc.ie/celt/published/G301900/text025.html>;
+    dcterms:format "text/turtle" ;
+    prov:asDerivedFrom <http://www.ucc.ie/celt/published/G301900/text025.html> .
+
+
+}


### PR DESCRIPTION
_De Genelogia Con Culaind_ is immediately preceded in LU by _Siaburcharpat Con Culaind_. The latter text concludes with a pedigree (LU ll.9541-9548) of Lóegaire Mac Néill back to Lugaid Riab nDerg, Cú Chulainn's foster-son. This is designed to prove that Cú Chulainn had brought back to life by Patrick (who arrived during Lórgaire's reign) after 900 years.

As this contextualises  _De Genelogia Con Culaind_ and is a physically early (well, hand H...) example of this pedigree, it seemed worth adding it to IrishGen.