### PR TITLE
Moved material to correct DA file

### DIFF
--- a/LL/dail_araide.trig
+++ b/LL/dail_araide.trig
@@ -30,7 +30,7 @@
 <#Aeda>
     a foaf:Person;
     irishRel:genName "Aeda";
-    irishRel:nomName "Aed";	
+    irishRel:nomName "Aed";
     rel:childOf <#Longsig>.
 
 <#Longsig>
@@ -127,13 +127,13 @@
 <#Lugdach>
     a foaf:Person;
     irishRel:genName "Lugdach";
-    irishRel:nomName "Lugdaid";	
+    irishRel:nomName "Lugdaid";
     rel:childOf <#Rosa>.
 
 <#Rosa>
     a foaf:Person;
     irishRel:genName "Rosa";
-    irishRel:nomName "Ross";    
+    irishRel:nomName "Ross";
     rel:childOf <#Imchada>.
 
 <#Imchada>
@@ -154,6 +154,54 @@
     irishRel:nomName "Mac Cass";
     rel:childOf <#FhiachachAraide>.
 
+# From this point on until otherwise indicated, the code follows a marginal insertion in the manuscript
+# which the CELT edition places elsewhere (https://celt.ucc.ie//published/G800011F/index.html). Analysis of
+# the context, however, suggests that this is the proper location for it. EPT
+
+<#AraideBibre>
+    a foaf:Person;
+    irishRel:nomName "Araide Bibre";
+    foaf:title "cáinte"@sga, "satirist"@eng;
+    foaf:title "rechtaire"@sga, "steward"@eng;
+    rel:employedBy <#Cormac>;
+    rdfs:comment "in cáinte de Mumnechaib ba sé ba rectaire do Chormac .h. Chuind".
+
+<#Cormac>
+    a foaf:Person;
+    irishRel:nomName "Cormac";
+    rel:descendantOf <#Chuind>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CormaicUlfhota>.
+
+<#Chuind>
+    a foaf:Person;
+    irishRel:genName "Chuind";
+    irishRel:nomName "Cond";
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CuindCetchathaig>;
+    owl:sameAs <#CondCetchathach>.
+
+<#Cairech>
+    a foaf:Person;
+    irishRel:nomName "Cairech";
+    foaf:gender "female";
+    rel:spouseOf <#AraideBibre>.
+
+<#Fiacha>
+    a foaf:Person;
+    irishRel:genName "Fiacha";
+    irishRel:nomName "Fiacha Araide";
+    owl:sameAs <#FhiachachAraide>;
+    rel:childOf <#Oengusa>;
+    irishRel:fosterChildOf <#Cairech>;
+    rdfs:comment "a quo Dal Araide".
+
+<#Oengusa>
+    a foaf:Person;
+    irishRel:genName "Oengusa";
+    irishRel:nomName "Oengus";
+    owl:sameAs <#OengusaGobnenn>.
+
+# This is the end of the marginal insertion (see comment above) and the main text resumes. EPT
+
 <#FhiachachAraide>
     a foaf:Person;
     irishRel:genName "Fhiachach Araide";
@@ -163,7 +211,7 @@
 <#OengusaGobnenn>
     a foaf:Person;
     irishRel:genName "Oengusa Gobnenn";
-    irishRel:nomName "Oengus Goibneen";	
+    irishRel:nomName "Oengus Goibneen";
     rel:childOf <#Fhergusa>.
 
 <#Fhergusa>
@@ -247,4 +295,3 @@
     irishRel:genName "Conaill Cernaig";
     irishRel:nomName "Conall Cernach".
 }
-

--- a/LL/dáil_araide.trig
+++ b/LL/dáil_araide.trig
@@ -179,54 +179,6 @@
     owl:sameAs <http://example.com/LL/dail_araide.trig#FhiachachAraide>;
     rel:childOf <#OengusaGoibnend>.
 
-# From this point on until otherwise indicated, the code follows a marginal insertion in the manuscript
-# which the CELT edition places elsewhere (https://celt.ucc.ie//published/G800011F/index.html). Analysis of
-# the context, however, suggests that this is the proper location for it. EPT
-
-<#AraideBibre>
-    a foaf:Person;
-    irishRel:nomName "Araide Bibre";
-    foaf:title "cáinte"@sga, "satirist"@eng;
-    foaf:title "rechtaire"@sga, "steward"@eng;
-    rel:employedBy <#Cormac>;
-    rdfs:comment "in cáinte de Mumnechaib ba sé ba rectaire do Chormac .h. Chuind".
-
-<#Cormac>
-    a foaf:Person;
-    irishRel:nomName "Cormac";
-    rel:descendantOf <#Chuind>;
-    owl:sameAs <http://example.com/LL/rig_ailig.trig#CormaicUlfhota>.
-
-<#Chuind>
-    a foaf:Person;
-    irishRel:genName "Chuind";
-    irishRel:nomName "Cond";
-    owl:sameAs <http://example.com/LL/rig_ailig.trig#CuindCetchathaig>;
-    owl:sameAs <#CondCetchathach>.
-
-<#Cairech>
-    a foaf:Person;
-    irishRel:nomName "Cairech";
-    foaf:gender "female";
-    rel:spouseOf <#AraideBibre>.
-
-<#Fiacha>
-    a foaf:Person;
-    irishRel:genName "Fiacha";
-    irishRel:nomName "Fiacha Araide";
-    owl:sameAs <#FiachachAraide>;
-    rel:childOf <#Oengusa>;
-    irishRel:fosterChildOf <#Cairech>;
-    rdfs:comment "a quo Dal Araide".
-
-<#Oengusa>
-    a foaf:Person;
-    irishRel:genName "Oengusa";
-    irishRel:nomName "Oengus";
-    owl:sameAs <#OengusaGoibnend>.
-
-# This is the end of the marginal insertion (see comment above) and the main text resumes. EPT
-
 <#OengusaGoibnend>
     a foaf:Person;
     irishRel:nomName "Oengusa Goibnend";


### PR DESCRIPTION
There are two files relating to Dál nAraide in LL, with very similar names. Earlier, I put the material that the scribe and later editors of the manuscript had also misplaced in the wrong Dál nAraide file. This moves the material to the correct file.