### PR TITLE
Pedigrees from the 1467 MS

### DIFF
--- a/LL/rig_alban.trig
+++ b/LL/rig_alban.trig
@@ -237,11 +237,16 @@ _:missing-02dcec05
     irishRel:genName "Echach Riatai";
     irishRel:nomName "Eochu Riata";
     rel:childOf <#Conaire>;
-    rdfs:comment "is eside Carpre Rigfhota".
+    rdfs:comment "is eside Carpre Rigfhota";
+    owl:sameAs <#CarpreRigfhota>.
     # is eside Carpre Rigfhota ? - CY
     # This is saying that Eochu Riata and Cairpre Rigfhota are the same person (in
     # other sources, Cairpre is Eochu's father). Should we create a separate entry
     # for Cairpre here or just add this as another name for Eochu? - EPT
+
+<#CarpreRigfhota>
+    a foaf:Person;
+    irishRel:nomName "Carpre Rigfhota".
 
 <#Conaire>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "kindred_1"@sga;
+    dcterms:title "Kindred 1"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2001.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2001.html> .

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
@@ -80,7 +80,8 @@
     irishRel:genName "Cinaethaig";
     irishRel:nomName "Cinaed";
     rel:childOf <#Ailpin>;
-    owl:sameAs <http://example.com/LL/rig_alban.trig#Cinaeda-7ff76313>.
+    owl:sameAs <http://example.com/LL/rig_alban.trig#Cinaeda-7ff76313>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q298263>.
     #This name is difficult to read in the MS. - EPT
 
 <#Ailpin>
@@ -249,7 +250,7 @@
     irishRel:genName "Cairpre Rifhoda";
     irishRel:nomName "Cairpre Rifhoda";
     rel:childOf <#ConaireCael>;
-    owl:sameAs <http://example.com/LL/rig_alban.trig#EchachRiatai>.
+    owl:sameAs <http://example.com/LL/rig_alban.trig#CarpreRigfhota>.
 
 <#ConaireCael>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig
@@ -30,22 +30,25 @@
     a foaf:Person;
     irishRel:genName "Maila";
     rel:childOf <#Fionnodg>.
-    #In cognate pedigrees, "Mael Colaim" comes here. - EPT
+    << <#Maila>
+          rdfs:comment "In cognate pedigrees, 'Mael Colaim' comes here." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Fionnodg>
     a foaf:Person;
     irishRel:genName "Fionnodg";
     rel:childOf <#Finnginn>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Fionnodg>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Finginn>
     a foaf:Person;
     irishRel:genName "Finginn";
     rel:childOf <#Mailcolaim>.
-    #It has been suggested (personal correspondence) that this individual, "Fingen mac Mail Cholaim",
-    #is derived from a misreading of "ingen Mail Colaim", which appears at this point in cognate
-    #pedigrees (e.g. https://celt.ucc.ie//published/G800011F/text068.html). The oddly named "Fionnodg",
-    #above, may also be somehow the product of this corruption. - EPT
+    << <#Finginn>
+          rdfs:comment "It has been suggested (personal correspondence) that this individual, 'Fingen mac Mail Cholaim', is derived from a misreading of 'ingen Mail Colaim', which appears at this point in cognate pedigrees (e.g. https://celt.ucc.ie//published/G800011F/text068.html). The oddly named 'Fionnodg', above, may also be somehow the product of this corruption." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#MaoilColaim>
     a foaf:Person;
@@ -82,7 +85,9 @@
     rel:childOf <#Ailpin>;
     owl:sameAs <http://example.com/LL/rig_alban.trig#Cinaeda-7ff76313>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q298263>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Cinaethaig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ailpin>
     a foaf:Person;
@@ -228,7 +233,9 @@
     irishRel:nomName "Eochaid Anndoid";
     rel:childOf <#Fiachach>;
     owl:sameAs <http://example.com/LL/rig_alban.trig#EchachAntóit>.
-    #This name is difficult to read in the MS. - EPT
+    << <#EathachAnndoid>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Fiachach>
     a foaf:Person;
@@ -236,7 +243,9 @@
     irishRel:nomName "Fiacha";
     rel:childOf <#EthachRiada>;
     owl:sameAs <http://example.com/LL/rig_alban.trig#Fhiachrach>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Fiachach>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#EthachRiada>
     a foaf:Person;
@@ -272,7 +281,9 @@
     irishRel:nomName "Lugaid Allathach";
     rel:childOf <#CairpreCroimcind>;
     owl:sameAs <http://example.com/LL/rig_alban.trig#Lugdech>.
-    #This name is difficult to read in the MS. - EPT
+    << <#LuigeachAllathaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#CairpreCroimcind>
     a foaf:Person;
@@ -308,7 +319,9 @@
     irishRel:nomName "Edersgel";
     rel:childOf <#Eoghan>;
     owl:sameAs <http://example.com/LL/rig_alban.trig#Etersceoil>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eidirsgeoil>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eoghan>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig
@@ -1,0 +1,157 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Labartaigh ann soth sis"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2010.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2010.html> .
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Colim>.
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#Colim>.
+
+<#Amlgolgaoi>
+    a foaf:Person;
+    irishRel:nomName "Amlgolgaoi";
+    rel:childOf <#Colim>.
+
+<#Colim>
+    a foaf:Person;
+    irishRel:genName "Colim";
+    irishRel:nomName "Colum";
+    rel:childOf <#Domnaill>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Eogain>.
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Baltair>.
+
+<#Baltair>
+    a foaf:Person;
+    irishRel:genName "Baltair";
+    irishRel:nomName "Baltar";
+    rel:childOf _:missing-ae4a9b70.
+
+_:missing-ae4a9b70
+    a foaf:Person;
+    rel:childOf <#Aeid>.
+    #This name is illegible in the MS. - EPT
+
+<#Aeid>
+    a foaf:Person;
+    irishRel:genName "Aeid";
+    irishRel:nomName "Aed";
+    rel:childOf <#Eogain-fe24a780>.
+
+<#Eogain-fe24a780>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Aig>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Aig>
+    a foaf:Person;
+    irishRel:genName "Aig";
+    irishRel:nomName "Aed";
+    rel:childOf <#Eisiab>.
+
+<#Eisiab>
+    a foaf:Person;
+    irishRel:genName "Eisiab";
+    rel:childOf <#GilleCrist>.
+
+<#GilleCrist>
+    a foaf:Person;
+    irishRel:genName "Gille Crist";
+    irishRel:nomName "Gille Crist";
+    rel:childOf <#GillaMhichel>.
+
+<#GillaMhichel>
+    a foaf:Person;
+    irishRel:genName "Gilla Mhichel";
+    irishRel:nomName "Gilla Michel";
+    rel:childOf <#Pilip>.
+
+<#Pilip>
+    a foaf:Person;
+    irishRel:genName "Pilip";
+    irishRel:nomName "Pilip";
+    rel:childOf <#FinnlaeithOig>.
+
+<#FinnlaeithOig>
+    a foaf:Person;
+    irishRel:genName "Finnlaeith Oig";
+    irishRel:nomName "Finnlaeth Og";
+    rel:childOf <#FinnlaeithMoir>.
+    #This name is difficult to read in the MS. - EPT
+
+<#FinnlaeithMoir>
+    a foaf:Person;
+    irishRel:genName "Finnlaeith Moir";
+    irishRel:nomName "Finnlaeth Mor";
+    rel:childOf <#Dubghaill>.
+
+<#Dubghaill>
+    a foaf:Person;
+    irishRel:genName "Dubghall";
+    irishRel:nomName "Dubghaill";
+    rel:childOf <#Baltuir>.
+
+<#Baltuir>
+    a foaf:Person;
+    irishRel:genName "Baltuir";
+    irishRel:nomName "Baltar";
+    rel:childOf <#Carlusa>.
+
+<#Carlusa>
+    a foaf:Person;
+    irishRel:genName "Carlusa";
+    rel:childOf <#DomnaillOig>.
+
+<#DomnaillOig>
+    a foaf:Person;
+    irishRel:genName "Domnaill Oig";
+    irishRel:nomName "Domnall Og";
+    rel:childOf <#DomnaillIDuinn>.
+
+<#DomnaillIDuinn>
+    a foaf:Person;
+    irishRel:genName "Domnaill Iduinn";
+    irishRel:nomName "Domnall Donn";
+    rel:childOf <#FearadaighFinn>.
+
+<#FearadaighFinn>
+    a foaf:person;
+    irishRel:genName "Fearadaigh Finn";
+    irishRel:nomName "Feradach Finn";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig
@@ -62,7 +62,9 @@
 _:missing-ae4a9b70
     a foaf:Person;
     rel:childOf <#Aeid>.
-    #This name is illegible in the MS. - EPT
+    << _:missing-ae4a9b70
+          rdfs:comment "This name is illegible in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Aeid>
     a foaf:Person;
@@ -75,7 +77,9 @@ _:missing-ae4a9b70
     irishRel:genName "Eogain";
     irishRel:nomName "Eogan";
     rel:childOf <#Aig>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eogain-fe24a780>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Aig>
     a foaf:Person;
@@ -111,7 +115,9 @@ _:missing-ae4a9b70
     irishRel:genName "Finnlaeith Oig";
     irishRel:nomName "Finnlaeth Og";
     rel:childOf <#FinnlaeithMoir>.
-    #This name is difficult to read in the MS. - EPT
+    << <#FinnlaeithOig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#FinnlaeithMoir>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
@@ -56,7 +56,9 @@
     a foaf:Person;
     irishRel:genName "Agad";
     rel:childOf <#GillaEoinOig>.
-    #Black suggests that this is the Norse name, "Agaðr". - EPT
+    << <#Agad>
+          rdfs:comment "Black suggests that this is the Norse name, 'Agaðr'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaEoinOig>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinni Cainnig"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2011.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2011.html>, <https://www.1467manuscript.co.uk/MacKenzie%20for%20web2.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2011.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2011.html>, <https://www.1467manuscript.co.uk/MacKenzie%20for%20web2.pdf>.
 
 <#Murchadh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
@@ -1,0 +1,72 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Cainnig"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2011.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2011.html> .
+
+<#Murchadh>
+    a foaf:Person;
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Cainnigh>.
+
+<#Cainnigh>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Cainnigh-9863bc80>.
+
+<#Cainnigh-9863bc80>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Aonghusa>.
+
+<#Aonghusa>
+    a foaf:Person;
+    irishRel:genName "Aonghusa";
+    irishRel:nomName "Aonghus";
+    rel:childOf <#Cristin>.
+
+<#Cristin>
+    a foaf:Person;
+    irishRel:genName "Cristin";
+    rel:childOf <#Agad>.
+
+<#Agad>
+    a foaf:Person;
+    irishRel:genName "Agad";
+    rel:childOf <#GillaEoinOig>.
+    #Black suggests that this should perhaps be read "Adhamh". - EPT
+
+<#GillaEoinOig>
+    a foaf:Person;
+    irishRel:genName "Gilla Eoin Oig";
+    irishRel:nomName "Gilla Eoin Og";
+    rel:childOf <#GillaEoinNahAird>.
+
+<#GillaEoinNahAird>
+    a foaf:Person;
+    irishRel:genName "Gilla Eoin na hAird";
+    irishRel:nomName "Gilla Eoin na hAird".
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig
@@ -56,7 +56,7 @@
     a foaf:Person;
     irishRel:genName "Agad";
     rel:childOf <#GillaEoinOig>.
-    #Black suggests that this should perhaps be read "Adhamh". - EPT
+    #Black suggests that this is the Norse name, "Agaðr". - EPT
 
 <#GillaEoinOig>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
@@ -1,0 +1,73 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Mathghamhna annso sis"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2012.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2012.html> .
+
+<#Murchadh>
+    a foaf:Person;
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Donnchaigh>.
+
+<#Donnchaigh>
+    a foaf:Person;
+    irishRel:genName "Donnchaigh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Murchaidh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#MurchaidhMoir>.
+
+<#MurchaidhMoir>
+    a foaf:Person;
+    irishRel:genName "Murchaidh Moir";
+    irishRel:nomName "Murchadh Mor";
+    rel:childOf <#Cainnigh>.
+
+<#Cainnigh>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Mathghamna>.
+
+<#Mathghamna>
+    a foaf:Person;
+    irishRel:genName "Mathghamna";
+    irishRel:nomName "Mathgamain";
+    rel:childOf <#Cainnigh-c1dc1f10>.
+
+<#Cainnigh-c1dc1f10>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Cristin>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Cristin>
+    a foaf:Person;
+    irishRel:genName "Cristin".
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
@@ -64,7 +64,9 @@
     a foaf:Person;
     irishRel:genName "Cainnigh";
     rel:childOf <#Cristin>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Cainnigh-c1dc1f10>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Cristin>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Mhic Mathghamhna annso sis"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2012.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2012.html>, <https://www.1467manuscript.co.uk/MathesonFinalforWEB.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2012.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2012.html>, <https://www.1467manuscript.co.uk/MathesonFinalforWEB.pdf>.
 
 <#Murchadh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -42,23 +42,22 @@
     a foaf:Person;
     irishRel:genName "Nicail";
     irishRel:nomName "Nical";
-    rel:childOf <#Aiga>.
+    rel:childOf <#Ingr>.
 
-<#Aiga>
+<#Ingr>
     a foaf:Person;
-    irishRel:genName "Aiga";
-    irishRel:nomName "Aed";
+    irishRel:genName "Ingr";
     rel:childOf <#Neailb>.
+    #Black suggests that this is a Norse name. - EPT
 
 <#Neailb>
     a foaf:Person;
     irishRel:genName "Neailb";
-    rel:childOf <#Grogall>.
-    #Black suggests that this should be read "Seailb". - EPT
+    rel:childOf <#Gregall>.
 
-<#Grogall>
+<#Gregall>
     a foaf:Person;
-    irishRel:genName "Grogall";
+    irishRel:genName "Gregall";
     rel:childOf <#GilleMuire>.
 
 <#GilleMuire>
@@ -145,11 +144,11 @@
     a foaf:Person;
     irishRel:genName "Thaidhg";
     irishRel:nomName "Tadhg";
-    rel:childOf <#Amlaeoim>.
+    rel:childOf <#Amlaeim>.
 
-<#Amlaeoim>
+<#Amlaeim>
     a foaf:Person;
-    irishRel:genName "Amlaeoim";
+    irishRel:genName "Amlaeim";
     irishRel:nomName "Amlaim";
     rel:childOf <#Turcaill>.
 
@@ -168,10 +167,15 @@
     a foaf:Person;
     irishRel:genName "Asmainn";
     irishRel:nomName "Asmann";
-    rel:childOf <#Arailt-632e9620>.
+    rel:childOf [
+      a foaf:Person;
+      foaf:title "ardiarla"@sga
+      #Black suggests that this should read "ardiarla orc" (son of the High Earl of Orkney).
+      #However, "orc" is expanded from a superscript "o" placed several characters to the left
+      #of "ardiarla", over the last syllable of "Amsmainn". For this reason, Black's reading
+      #is not totally satisfactory, although I have no other way of accounting for the "o". - EPT
+    ].
 
-<#Arailt-632e9620>
-    a foaf:Person;
-    irishRel:genName "Arailt".
+
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -1,0 +1,177 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Clann Mhic Nicail"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2013.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2013.html> .
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Eogain>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Eoin-2c82af50>.
+
+<#Eoin-2c82af50>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Nicail>.
+
+<#Nicail>
+    a foaf:Person;
+    irishRel:genName "Nicail";
+    irishRel:nomName "Nical";
+    rel:childOf <#Aiga>.
+
+<#Aiga>
+    a foaf:Person;
+    irishRel:genName "Aiga";
+    irishRel:nomName "Aed";
+    rel:childOf <#Neailb>.
+
+<#Neailb>
+    a foaf:Person;
+    irishRel:genName "Neailb";
+    rel:childOf <#Grogall>.
+    #Black suggests that this should be read "Seailb". - EPT
+
+<#Grogall>
+    a foaf:Person;
+    irishRel:genName "Grogall";
+    rel:childOf <#GilleMuire>.
+
+<#GilleMuire>
+    a foaf:Person;
+    irishRel:genName "Gille Muire";
+    irishRel:nomName "Gille Muire";
+    rel:childOf <#Sealbaigh>.
+
+<#Sealbaigh>
+    a foaf:Person;
+    irishRel:genName "Sealbaigh";
+    irishRel:nomName "Sealbach";
+    rel:childOf <#Toircinn>.
+
+<#Toircinn>
+    a foaf:Person;
+    irishRel:genName "Toircinn";
+    irishRel:nomName "Toircenn";
+    rel:childOf <#Tortha>.
+
+<#Tortha>
+    a foaf:Person;
+    irishRel:genName "Tortha";
+    rel:childOf <#Trostain>.
+
+<#Trostain>
+    a foaf:Person;
+    irishRel:genName "Trostain";
+    irishRel:nomName "Trostan";
+    rel:childOf <#Sdacaill>.
+
+<#Sdacaill>
+    a foaf:Person;
+    irishRel:genName "Sdacaill";
+    irishRel:nomName "Sdacall";
+    rel:childOf <#Erble>.
+
+<#Erble>
+    a foaf:Person;
+    irishRel:genName "Erble";
+    rel:childOf <#Arailt>;
+    rdfs:comment "o fuilid Mic Erble";
+    irishRel:ancestorOfGroup <#MicErble>.
+
+<#MicErble>
+    a irishRel:PopulationGroup;
+    irishRel:populationGroupName "Mic Erble".
+
+<#Arailt>
+    a foaf:Person;
+    irishRel:genName "Arailt";
+    rel:childOf <#Murchaidh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Fhoghail>.
+
+<#Fhoghail>
+    a foaf:Person;
+    irishRel:genName "Fhoghail";
+    irishRel:nomName "Foghal";
+    rel:childOf <#Poil>.
+
+<#Poil>
+    a foaf:Person;
+    irishRel:genName "Poil";
+    irishRel:nomName "Pol";
+    rel:childOf <#Ailin>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailin";
+    rel:childOf <#Airfinn>.
+
+<#Airfinn>
+    a foaf:Person;
+    irishRel:genName "Airfinn";
+    rel:childOf <#Thaidhg>.
+
+<#Thaidhg>
+    a foaf:Person;
+    irishRel:genName "Thaidhg";
+    irishRel:nomName "Tadhg";
+    rel:childOf <#Amlaeoim>.
+
+<#Amlaeoim>
+    a foaf:Person;
+    irishRel:genName "Amlaeoim";
+    irishRel:nomName "Amlaim";
+    rel:childOf <#Turcaill>.
+
+<#TurcaillAthaCliath>
+    a foaf:Person;
+    irishRel:genName "Turcaill Atha Cliatha";
+    irishRel:nomName "Turcall Atha Cliatha";
+    rel:childOf <#Arailt-3a6f3870>.
+
+<#Arailt-3a6f3870>
+    a foaf:Person;
+    irishRel:genName "Arailt";
+    rel:childOf <#Asmainn>.
+
+<#Asmainn>
+    a foaf:Person;
+    irishRel:genName "Asmainn";
+    irishRel:nomName "Asmann";
+    rel:childOf <#Arailt-632e9620>.
+
+<#Arailt-632e9620>
+    a foaf:Person;
+    irishRel:genName "Arailt".
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -168,7 +168,7 @@
     irishRel:genName "Asmainn";
     irishRel:nomName "Asmann";
     rel:childOf [
-      a foaf:Person;
+      a IrishTitles:Íarla;
       foaf:title "ardiarla"@sga
       #Black suggests that this should read "ardiarla orc" (son of the High Earl of Orkney).
       #However, "orc" is expanded from a superscript "o" placed several characters to the left

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -174,7 +175,7 @@
     rel:childOf _:missing-f7dbf9a0.
 
 _:missing-f7dbf9a0
-    a IrishTitles:Íarla;
+    a IrishTitle:Íarla;
     foaf:title "ardiarla"@sga, "high earl"@eng.
     << _:missing-f7dbf9a0
           rdfs:comment "Black suggests that this should read 'ardiarla orc' (son of the High Earl of Orkney). However, 'orc' is expanded from a superscript 'o' placed several characters to the left of 'ardiarla', over the last syllable of 'Amsmainn'. For this reason, Black's reading is not totally satisfactory, although I have no other way of accounting for the 'o'." >>

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Clann Mhic Nicail"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2013.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2013.html>, <https://www.1467manuscript.co.uk/Nicolsonforweb.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2013.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2013.html>, <https://www.1467manuscript.co.uk/Nicolsonforweb.pdf>.
 
 <#Eoin>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_13.trig
@@ -24,7 +24,9 @@
     a foaf:Person;
     irishRel:nomName "Eoin";
     rel:childOf <#Eogain>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eoin>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eogain>
     a foaf:Person;
@@ -48,7 +50,9 @@
     a foaf:Person;
     irishRel:genName "Ingr";
     rel:childOf <#Neailb>.
-    #Black suggests that this is a Norse name. - EPT
+    << <#Ingr>
+          rdfs:comment "Black suggests that this is a Norse name." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Neailb>
     a foaf:Person;
@@ -167,15 +171,13 @@
     a foaf:Person;
     irishRel:genName "Asmainn";
     irishRel:nomName "Asmann";
-    rel:childOf [
-      a IrishTitles:Íarla;
-      foaf:title "ardiarla"@sga
-      #Black suggests that this should read "ardiarla orc" (son of the High Earl of Orkney).
-      #However, "orc" is expanded from a superscript "o" placed several characters to the left
-      #of "ardiarla", over the last syllable of "Amsmainn". For this reason, Black's reading
-      #is not totally satisfactory, although I have no other way of accounting for the "o". - EPT
-    ].
+    rel:childOf _:missing-f7dbf9a0.
 
-
+_:missing-f7dbf9a0
+    a IrishTitles:Íarla;
+    foaf:title "ardiarla"@sga, "high earl"@eng.
+    << _:missing-f7dbf9a0
+          rdfs:comment "Black suggests that this should read 'ardiarla orc' (son of the High Earl of Orkney). However, 'orc' is expanded from a superscript 'o' placed several characters to the left of 'ardiarla', over the last syllable of 'Amsmainn'. For this reason, Black's reading is not totally satisfactory, although I have no other way of accounting for the 'o'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
@@ -20,15 +20,12 @@
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2014.html> .
 
-<#Pal>
+<#PalMacTire>
     a foaf:Person;
-    irishRel:nomName "Pal";
-    rel:childOf <#Tire>.
-
-<#Tire>
-    a foaf:Person;
-    irishRel:genName "Tire";
+    irishRel:nomName "Pal Mac Tire";
     rel:childOf <#Eoghain>.
+    #As Black points out, "Mac Tire" is a kenning for "wolf" and is probably
+    #Pal's nickname. - EPT
 
 <#Eoghain>
     a foaf:Person;
@@ -132,5 +129,7 @@
     irishRel:genName "Feradaigh";
     irishRel:nomName "Feradach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Ferchairdi>.
+    #More text appears after this name (the remaining third of the MS line) but it is very faint even
+    #in Black's multi-spectral images. - EPT 
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinne Ainnrias"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2014.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2014.html>, <https://www.1467manuscript.co.uk/Gillanders2web.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2014.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2014.html>, <https://www.1467manuscript.co.uk/Gillanders2web.pdf>.
 
 <#PalMacTire>
     a foaf:Person;
@@ -130,6 +130,6 @@
     irishRel:nomName "Feradach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Ferchairdi>.
     #More text appears after this name (the remaining third of the MS line) but it is very faint even
-    #in Black's multi-spectral images. - EPT 
+    #in Black's multi-spectral images. - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
@@ -1,0 +1,134 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinne Ainnrias"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2014.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2014.html> .
+
+<#Pal>
+    a foaf:Person;
+    irishRel:nomName "Pal";
+    rel:childOf <#Tire>.
+
+<#Tire>
+    a foaf:Person;
+    irishRel:genName "Tire";
+    rel:childOf <#Eoghain>.
+
+<#Eoghain>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Muiredhaigh>.
+
+<#Muiredhaigh>
+    a foaf:Person;
+    irishRel:genName "Fail";
+    irishRel:nomName "Pal";
+    rel:childOf <#GilleAinnrias>.
+
+<#GilleAinnrias>
+    a foaf:Person;
+    irishRel:genName "Gille Ainnrias";
+    irishRel:nomName "Gille Ainnrias";
+    rel:childOf <#Martain>.
+
+<#Martain>
+    a foaf:Person;
+    irishRel:genName "Martain";
+    irishRel:nomName "Martan";
+    rel:childOf <#Foil>.
+
+<#Foil>
+    a foaf:Person;
+    irishRel:genName "Foil";
+    irishRel:nomName "Fol";
+    rel:childOf <#Cainnigh>.
+
+<#Cainnigh>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Cristin>.
+
+<#Cristin>
+    a foaf:Person;
+    irishRel:genName "Cristin";
+    rel:childOf <#Eoghain-637fa6e0>.
+
+<#Eoghain-637fa6e0>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Cainnigh-821d5430>.
+
+<#Cainnigh-821d5430>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    rel:childOf <#Cristin-99514530>.
+
+<#Cristin-99514530>
+    a foaf:Person;
+    irishRel:genName "Cristin";
+    rel:childOf <#GilleEoinNahAirde>.
+
+<#GilleEoinNahAirde>
+    a foaf:Person;
+    irishRel:genName "Gilla Eoin na hAirde";
+    irishRel:nomName "Gilla Eoin na hAirde";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_11.trig#GillaEoinNahAird>;
+    rel:childOf <#Eirc>.
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#Loairn>.
+
+<#Loairn>
+    a foaf:Person;
+    irishRel:genName "Loairn";
+    irishRel:nomName "Loarn";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Cormaic>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
+
+<#Feradaigh>
+    a foaf:Person;
+    irishRel:genName "Feradaigh";
+    irishRel:nomName "Feradach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Ferchairdi>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
@@ -79,12 +79,14 @@
 <#Cainnigh-821d5430>
     a foaf:Person;
     irishRel:genName "Cainnigh";
-    rel:childOf <#Cristin-99514530>.
+    rel:childOf <#Cristin-99514530>;
+    owl:SameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig#Cainnigh-c1dc1f10>.
 
 <#Cristin-99514530>
     a foaf:Person;
     irishRel:genName "Cristin";
-    rel:childOf <#GilleEoinNahAirde>.
+    rel:childOf <#GilleEoinNahAirde>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_12.trig#Cristin>.
 
 <#GilleEoinNahAirde>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig
@@ -24,8 +24,9 @@
     a foaf:Person;
     irishRel:nomName "Pal Mac Tire";
     rel:childOf <#Eoghain>.
-    #As Black points out, "Mac Tire" is a kenning for "wolf" and is probably
-    #Pal's nickname. - EPT
+    << <#PalMacTire>
+          rdfs:comment "As Black points out, 'Mac Tire' is a kenning for 'wolf' and is probably Pal's nickname." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eoghain>
     a foaf:Person;
@@ -129,7 +130,8 @@
     irishRel:genName "Feradaigh";
     irishRel:nomName "Feradach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Ferchairdi>.
-    #More text appears after this name (the remaining third of the MS line) but it is very faint even
-    #in Black's multi-spectral images. - EPT
+    << <#Feradaigh>
+          rdfs:comment "More text appears after this name (the remaining third of the MS line) but it is very faint even in Black's multi-spectral images." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
@@ -97,7 +97,9 @@
     irishRel:genName "Eirenain";
     irishRel:nomName "Eirenan";
     rel:childOf <#Meirbi>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eirenain>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Meirbi>
     a foaf:Person;
@@ -116,6 +118,8 @@
     irishRel:genName "Iubair";
     irishRel:nomName "Iubar";
     rdfs:comment ".i. righ in domain gan rusan".
-    #Black amends the final word of the comment to "imresan". - EPT
+    << <#Iubair>
+          rdfs:comment "Black amends the final word of the comment to 'imresan'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
@@ -16,15 +16,15 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinni Cailin ann so"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2015.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2015.html>, <https://www.1467manuscript.co.uk/campbells.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2015.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2015.html>, <https://www.1467manuscript.co.uk/campbells.pdf>.
 
 <#CailinOg>
     a foaf:Person;
     irishRel:nomName "Cailin Og";
     rel:childOf <#GilleEaspuig>.
-    
+
 <#GilleEaspuig>
     a foaf:Person;
     irishRel:genName "Gille Easpuig";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig
@@ -1,0 +1,121 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_15.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Cailin ann so"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2015.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2015.html> .
+
+<#CailinOg>
+    a foaf:Person;
+    irishRel:nomName "Cailin Og";
+    rel:childOf <#GilleEaspuig>.
+    
+<#GilleEaspuig>
+    a foaf:Person;
+    irishRel:genName "Gille Easpuig";
+    irishRel:nomName "Gille Easpuig";
+    rel:childOf <#Cailin>.
+
+<#Cailin>
+    a foaf:Person;
+    irishRel:genName "Cailin";
+    irishRel:nomName "Cailin";
+    rel:childOf <#Ailin>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailin";
+    rel:childOf <#Neill>.
+
+<#Neill>
+    a foaf:Person;
+    irishRel:genName "Neill";
+    irishRel:nomName "Niall";
+    rel:childOf <#AilinMoir>.
+
+<#AilinMoir>
+    a foaf:Person;
+    irishRel:genName "Ailin Moir";
+    irishRel:nomName "Ailin Mor";
+    rel:childOf <#GilleEspuig>.
+
+<#GilleEspuig>
+    a foaf:Person;
+    irishRel:genName "Gille Espuig";
+    irishRel:nomName "Gille Espuig";
+    rel:childOf <#Dubgaill>.
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#GilleEaspuig-488a3380>.
+
+<#GilleEaspuig-488a3380>
+    a foaf:Person;
+    irishRel:genName "Gille Easpuig";
+    irishRel:nomName "Gille Easpuig";
+    rel:childOf <#GilleColaim>.
+
+<#GilleColaim>
+    a foaf:Person;
+    irishRel:genName "Gille Colaim";
+    irishRel:nomName "Gille Colaim";
+    rdfs:comment "renabartha mac Duibne";
+    rel:childOf <#Duibne>.
+
+<#Duibne>
+    a foaf:Person;
+    irishRel:genName "Duibne";
+    irishRel:nomName "Duibne";
+    rel:childOf <#Eirenain>.
+
+<#Eirenain>
+    a foaf:Person;
+    irishRel:genName "Eirenain";
+    irishRel:nomName "Eirenan";
+    rel:childOf <#Meirbi>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Meirbi>
+    a foaf:Person;
+    irishRel:genName "Meirbi";
+    irishRel:nomName "Meirbe";
+    rel:childOf <#Artuir>.
+
+<#Artuir>
+    a foaf:Person;
+    irishRel:genName "Artuir";
+    irishRel:nomName "Artur";
+    rel:childOf <#Iubair>.
+
+<#Iubair>
+    a foaf:Person;
+    irishRel:genName "Iubair";
+    irishRel:nomName "Iubar";
+    rdfs:comment ".i. righ in domain gan rusan".
+    #Black amends the final word of the comment to "imresan". - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
@@ -27,31 +27,31 @@
 
 <#Imhair>
     a foaf:Person;
-    irishRel:genName "Imhair"
+    irishRel:genName "Imhair";
     irishRel:nomName "Imhar";
     rel:childOf <#GillaCrist>.
 
 <#GillaCrist>
     a foaf:Person;
-    irishRel:genName "Gilla Crist"
+    irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
     rel:childOf <#GillaEaspaig>.
 
 <#GillaEaspaig>
     a foaf:Person;
-    irishRel:genName "Gilla Easpaig"
+    irishRel:genName "Gilla Easpaig";
     irishRel:nomName "Gilla Easpaig";
     rel:childOf <#GillaNaNaemh>.
 
 <#GillaNaNaemh>
     a foaf:Person;
-    irishRel:genName "Gilla na Naemh"
+    irishRel:genName "Gilla na Naemh";
     irishRel:nomName "Gilla na Naemh";
     rel:childOf <#GillaCrist-c2bb5930>.
 
 <#GillaCrist-c2bb5930>
     a foaf:Person;
-    irishRel:genName "Gilla Crist"
+    irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
     rel:childOf <#Cormaic>.
 
@@ -63,19 +63,19 @@
 
 <#GillaMichel>
     a foaf:Person;
-    irishRel:genName "Gilla Michel"
+    irishRel:genName "Gilla Michel";
     irishRel:nomName "Gilla Michel";
     rel:childOf <#Aidh>.
 
 <#Aidh>
     a foaf:Person;
-    irishRel:genName "Aidh"
+    irishRel:genName "Aidh";
     irishRel:nomName "Aedh";
     rel:childOf <#Gallbairt>.
 
 <#Gallbairt>
     a foaf:Person;
-    irishRel:genName "Gallbairt"
+    irishRel:genName "Gallbairt";
     irishRel:nomName "Gallbart";
     rdfs:comment ".i. in fer leginn risinabartha Gallbairt";
     rel:childOf <#GillaChatan>.

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
@@ -1,0 +1,150 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Aidh annso"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2016.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2016.html> .
+
+<#Fearchar>
+    a foaf:Person;
+    irishRel:nomName "Fearchar";
+    rel:childOf <#Imhair>.
+
+<#Imhair>
+    a foaf:Person;
+    irishRel:genName "Imhair"
+    irishRel:nomName "Imhar";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist"
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#GillaEaspaig>.
+
+<#GillaEaspaig>
+    a foaf:Person;
+    irishRel:genName "Gilla Easpaig"
+    irishRel:nomName "Gilla Easpaig";
+    rel:childOf <#GillaNaNaemh>.
+
+<#GillaNaNaemh>
+    a foaf:Person;
+    irishRel:genName "Gilla na Naemh"
+    irishRel:nomName "Gilla na Naemh";
+    rel:childOf <#GillaCrist-c2bb5930>.
+
+<#GillaCrist-c2bb5930>
+    a foaf:Person;
+    irishRel:genName "Cormaic"
+    irishRel:nomName "Cormac";
+    rel:childOf <#GillaMichel>.
+
+<#GillaMichel>
+    a foaf:Person;
+    irishRel:genName "Gilla Michel"
+    irishRel:nomName "Gilla Michel";
+    rel:childOf <#Aidh>.
+
+<#Aidh>
+    a foaf:Person;
+    irishRel:genName "Aidh"
+    irishRel:nomName "Aedh";
+    rel:childOf <#Gallbairt>.
+
+<#Gallbairt>
+    a foaf:Person;
+    irishRel:genName "Gallbairt"
+    irishRel:nomName "Gallbart";
+    rel:childOf _:missing-36214790.
+
+_:missing-36214790
+    a foaf:Person;
+    rdfs:comment ".i. in fer eges risinabartha gall[bairt]";
+    rel:childOf <#Domnaill>.
+    #Part of a name ("[...]rtan") is visible in the MS. - EPT
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Eogain>.
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Filip>.
+
+<#Filip>
+    a foaf:Person;
+    irishRel:genName "Filip";
+    irishRel:nomName "Filip";
+    rel:childOf <#Oisiab>.
+
+<#Oisiab>
+    a foaf:Person;
+    irishRel:genName "Oisiab";
+    rel:childOf <#Eirc>.
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#Aengusa>.
+
+<#Aengusa>
+    a foaf:Person;
+    irishRel:genName "Aengusa";
+    irishRel:nomName "Aengus";
+    rel:childOf <#Fhinnlaeith>.
+
+<#Fhinnlaeith>
+    a foaf:Person;
+    irishRel:genName "Fhinnlaeith";
+    irishRel:nomName "Finnlaeth";
+    rel:childOf <#Carla>.
+
+<#Carla>
+    a foaf:Person;
+    irishRel:genName "Carla";
+    rel:childOf <#DomnaillOig>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#Carlusa>.
+
+<#DomnaillOig>
+    a foaf:Person;
+    irishRel:genName "Domnaill Oig";
+    irishRel:nomName "Domnall Og";
+    rel:childOf <#DomnaillDuinn>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#DomnaillOig>.
+
+<#DomnaillDuinn>
+    a foaf:Person;
+    irishRel:genName "Domnaill Duinn";
+    irishRel:nomName "Domnall Donn";
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#DomnaillIDuinn>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#FearadaighFinn>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
@@ -51,7 +51,13 @@
 
 <#GillaCrist-c2bb5930>
     a foaf:Person;
-    irishRel:genName "Cormaic"
+    irishRel:genName "Gilla Crist"
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
     irishRel:nomName "Cormac";
     rel:childOf <#GillaMichel>.
 
@@ -71,13 +77,15 @@
     a foaf:Person;
     irishRel:genName "Gallbairt"
     irishRel:nomName "Gallbart";
-    rel:childOf _:missing-36214790.
+    rdfs:comment ".i. in fer leginn risinabartha Gallbairt";
+    rel:childOf <#GillaChatan>.
+    #The comment is written after "Gilla Chatan" but seems to relate to this person. - EPT
 
-_:missing-36214790
+<#GillaChatan>
     a foaf:Person;
-    rdfs:comment ".i. in fer eges risinabartha gall[bairt]";
+    irishRel:genName "Gilla Chatan";
+    irishRel:nomName "Gilla Catan";
     rel:childOf <#Domnaill>.
-    #Part of a name ("[...]rtan") is visible in the MS. - EPT
 
 <#Domnaill>
     a foaf:Person;
@@ -137,13 +145,13 @@ _:missing-36214790
     a foaf:Person;
     irishRel:genName "Domnaill Duinn";
     irishRel:nomName "Domnall Donn";
-    rel:childOf <#Feradhaigh>;
+    rel:childOf <#Feradhaig>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#DomnaillIDuinn>.
     #This name is difficult to read in the MS. - EPT
 
-<#Feradhaigh>
+<#Feradhaig>
     a foaf:Person;
-    irishRel:genName "Feradhaigh";
+    irishRel:genName "Feradhaig";
     irishRel:nomName "Feradach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#FearadaighFinn>.
 

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
@@ -79,7 +79,9 @@
     irishRel:nomName "Gallbart";
     rdfs:comment ".i. in fer leginn risinabartha Gallbairt";
     rel:childOf <#GillaChatan>.
-    #The comment is written after "Gilla Chatan" but seems to relate to this person. - EPT
+    << <#Gallbairt>
+          rdfs:comment "The comment is written after 'Gilla Chatan' but seems to relate to this person." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaChatan>
     a foaf:Person;
@@ -147,7 +149,9 @@
     irishRel:nomName "Domnall Donn";
     rel:childOf <#Feradhaig>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_10.trig#DomnaillIDuinn>.
-    #This name is difficult to read in the MS. - EPT
+    << <#DomnaillDuinn>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Feradhaig>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_16.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinni Aidh annso"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2016.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2016.html>, <https://www.1467manuscript.co.uk/Mackay2%20FOR%20WEB.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2016.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2016.html>, <https://www.1467manuscript.co.uk/Mackay2%20FOR%20WEB.pdf>.
 
 <#Fearchar>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_17.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_17.trig
@@ -1,0 +1,138 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_17.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Duibshithi annso"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2017.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2017.html> .
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#GillaEspaigRuaidh>.
+
+<#Niall>
+    a foaf:Person;
+    irishRel:nomName "Niall";
+    rel:childOf <#GillaEspaigRuaidh>.
+
+<#GillaColaim>
+    a foaf:Person;
+    irishRel:nomName "GillaColaim";
+    rel:childOf <#GillaEspaigRuaidh>.
+
+<#GillaEspaigRuaidh>
+    a foaf:Person;
+    irishRel:genName "Gilla Espaig Ruaidh";
+    irishRel:nomName "Gilla Espaig Ruadh";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#GhillaColaim>.
+
+<#GhillaColaim>
+    a foaf:Person;
+    irishRel:genName "Ghilla Colaim";
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#DubghaillMoir>.
+
+<#DubghaillMoir>
+    a foaf:Person;
+    irishRel:genName "Dubghaill Moir";
+    irishRel:nomName "Dubghall Mor";
+    rel:childOf <#Dhuibshithi>.
+
+<#Dhuibshithi>
+    a foaf:Person;
+    irishRel:genName "Dhuibshithi";
+    irishRel:nomName "Duibshithe";
+    rel:childOf <#Murchaidh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#FinnlaeithChais>.
+
+<#FinnlaeithChais>
+    a foaf:Person;
+    irishRel:genName "Finnlaeith Chais";
+    irishRel:nomName "Finnlaeth Cas";
+    rel:childOf <#Murchaidh-10c6d0a0>.
+
+<#Murchaidh-10c6d0a0>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Dubgaill>.
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#Finnlaeich>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Finnlaeich>
+    a foaf:Person;
+    irishRel:genName "Finnlaeich";
+    irishRel:nomName "Finnlaech";
+    rel:childOf <#Ferchair>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Cormaic>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_14.trig#Ferchair>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Cormaic>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#FerchairFhada>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#FerchairFhada>
+    a foaf:Person;
+    irishRel:genName "Ferchair Fhada";
+    irishRel:nomName "Ferchar Fada";
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+    #This name is difficult to read in the MS. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_17.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_17.trig
@@ -64,7 +64,9 @@
     irishRel:genName "Dhuibshithi";
     irishRel:nomName "Duibshithe";
     rel:childOf <#Murchaidh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Dhuibshithi>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Murchaidh>
     a foaf:Person;
@@ -89,14 +91,18 @@
     irishRel:genName "Dubgaill";
     irishRel:nomName "Dubgall";
     rel:childOf <#Finnlaeich>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Dubgaill>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Finnlaeich>
     a foaf:Person;
     irishRel:genName "Finnlaeich";
     irishRel:nomName "Finnlaech";
     rel:childOf <#Ferchair>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Finnlaeich>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ferchair>
     a foaf:Person;
@@ -118,7 +124,9 @@
     irishRel:nomName "Airbertach";
     rel:childOf <#FerchairFhada>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Airbertaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#FerchairFhada>
     a foaf:Person;
@@ -126,13 +134,17 @@
     irishRel:nomName "Ferchar Fada";
     rel:childOf <#Feradhaigh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
-    #This name is difficult to read in the MS. - EPT
+    << <#FerchairFhada>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Feradhaigh>
     a foaf:Person;
     irishRel:genName "Feradhaigh";
     irishRel:nomName "Feradach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Feradhaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -99,7 +99,7 @@
     #This name is difficult to read in the MS. - EPT
 
 <#GillaCrist>
-    a foaf:Person;
+    a IrishTitles:Abb;
     irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
     rdfs:comment "in tris ab ar sainganndrias";
@@ -153,7 +153,7 @@ _:missing-01e355a0
     #This name is difficult to read in the MS. - EPT
 
 _:missing-66a13c40
-    a foaf:Person;
+    a IrishTitles:Barún;
     foaf:title "an baran"@sga, "the baron"@eng;
     rel:childOf <#Conaill>.
     #This entry is difficult to read in the MS. - EPT
@@ -185,11 +185,11 @@ _:missing-66a13c40
     #This name is difficult to read in the MS. - EPT
 
 <#Dugaill>
-    a foaf:Person;
+    a IrishTitles:FerLéiginn;
     irishRel:genName "Dugaill";
     irishRel:nomName "Dubgall";
     rdfs:comment "an fer leiginn ruadh";
-    foaf:title "fer leiginn"@sga, "lector"@eng.
+    foaf:title "fer leiginn"@sga, "scholar"@eng.
     #The name and comment are difficult to read in the MS. - EPT
 
 

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -36,7 +36,9 @@
     irishRel:genName "Imair";
     irishRel:nomName "Imar";
     rel:childOf <#Imair>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Imair>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCrist>
     a foaf:Person;
@@ -96,7 +98,9 @@
     irishRel:genName "Muirethaigh";
     irishRel:nomName "Muiredach";
     rel:childOf <#GillaCrist>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Muirethaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCrist>
     a IrishTitles:Abb;
@@ -105,58 +109,76 @@
     rdfs:comment "in tris ab ar sainganndrias";
     foaf:title "ab"@sga, "abbot"@eng;
     rel:childOf <#Ectigerna>.
-    #The name and comment are very difficult to read in the MS. - EPT
+    << <#GillaCrist>
+          rdfs:comment "The name and comment are very difficult to read in the MS" >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ectigerna>
     a foaf:Person;
     irishRel:genName "Ectigerna";
     irishRel:nomName "Echtigern";
     rel:childOf _:missing-01e355a0.
-    #This name is difficult to read in the MS. - EPT
+    << <#Ectigerna>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-01e355a0
     a foaf:Person;
     rel:childOf <#GillandriasMoir>.
-    #This name is omitted ("mhic mhic") in the MS. - EPT
+    << _:missing-01e355a0
+          rdfs:comment "This name is omitted ('mhic mhic') in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillandriasMoir>
     a foaf:Person;
     irishRel:genName "Gillandrias Moir";
     irishRel:nomName "Gille Andrias Mor";
     rel:childOf <#Eittigerna>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillandriasMoir>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eittigerna>
     a foaf:Person;
     irishRel:genName "Eittigerna";
     irishRel:nomName "Echthigern";
     rel:childOf <#Ath>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eittigerna>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ath>
     a foaf:Person;
     irishRel:genName "Ath";
     irishRel:nomName "Aed".
-    #The comment is difficult to read in the MS. - EPT
+    << <#Ath>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Echtigern>
     a foaf:Person;
     irishRel:genName "Echtigerne";
     irishRel:nomName "Echthigern";
     rel:childOf <#Betain>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Echtigern>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Betain>
     a foaf:Person;
     irishRel:genName "Betain";
     rel:childOf _:missing-66a13c40.
-    #This name is difficult to read in the MS. - EPT
+    << <#Betain>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-66a13c40
     a IrishTitles:Barún;
     foaf:title "an baran"@sga, "the baron"@eng;
     rel:childOf <#Conaill>.
-    #This entry is difficult to read in the MS. - EPT
+    << _:missing-66a13c40
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Conaill>
     a foaf:Person;
@@ -169,20 +191,26 @@ _:missing-66a13c40
     irishRel:genName "Cormaic";
     irishRel:nomName "Cormac";
     rel:childOf <#Eachthigerna>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Cormaic-8300c3f0>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eachthigerna>
     a foaf:Person;
     irishRel:genName "Eatach";
     irishRel:nomName "Eochu";
     rel:childOf <#BeithirMoir>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eachthigerna>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#BeithirMoir>
     a foaf:Person;
     irishRel:genName "Beithir Moir";
     rel:childOf <#Dugaill>.
-    #This name is difficult to read in the MS. - EPT
+    << <#BeithirMoir>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Dugaill>
     a IrishTitles:FerLéiginn;
@@ -190,7 +218,9 @@ _:missing-66a13c40
     irishRel:nomName "Dubgall";
     rdfs:comment "an fer leiginn ruadh";
     foaf:title "fer leiginn"@sga, "scholar"@eng.
-    #The name and comment are difficult to read in the MS. - EPT
+    << <#Dugaill>
+          rdfs:comment "This name and the comment are difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -103,7 +104,7 @@
           prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCrist>
-    a IrishTitles:Abb;
+    a IrishTitle:Abb;
     irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
     rdfs:comment "in tris ab ar sainganndrias";
@@ -173,7 +174,7 @@ _:missing-01e355a0
           prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-66a13c40
-    a IrishTitles:Barún;
+    a IrishTitle:Barún;
     foaf:title "an baran"@sga, "the baron"@eng;
     rel:childOf <#Conaill>.
     << _:missing-66a13c40
@@ -213,7 +214,7 @@ _:missing-66a13c40
           prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Dugaill>
-    a IrishTitles:FerLéiginn;
+    a IrishTitle:FerLéiginn;
     irishRel:genName "Dugaill";
     irishRel:nomName "Dubgall";
     rdfs:comment "an fer leiginn ruadh";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -1,0 +1,211 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Echthigerna"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2018.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2018.html> .
+
+<#GillaAinndrias>
+    a foaf:Person;
+    irishRel:nomName "Gilla Ainndrias";
+    rel:childOf <#Cailin>.
+
+<#Cailin>
+    a foaf:Person;
+    irishRel:genName "Cailin";
+    irishRel:nomName "Cailin";
+    rel:childOf <#Imair>.
+
+<#Imair>
+    a foaf:Person;
+    irishRel:genName "Imair";
+    irishRel:nomName "Imar";
+    rel:childOf <#Imair>.
+    #This name is difficult to read in the MS. - EPT
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Mhicraith>.
+
+<#Mhicraith>
+    a foaf:Person;
+    irishRel:genName "Mhicraith";
+    irishRel:nomName "Macraith";
+    rel:childOf <#Muirchertaigh>.
+
+<#Muirchertaigh>
+    a foaf:Person;
+    irishRel:genName "Muirchertaigh";
+    irishRel:nomName "Muirchertach";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Oisiab>.
+
+<#Oisiab>
+    a foaf:Person;
+    irishRel:genName "Oisiab";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Finnlaeith>.
+
+<#Finnlaeith>
+    a foaf:Person;
+    irishRel:genName "Finnlaeith";
+    irishRel:nomName "Finnlaeth";
+    rel:childOf <#Nicail>.
+
+<#Nicail>
+    a foaf:Person;
+    irishRel:genName "Nicail";
+    irishRel:nomName "Nical";
+    rel:childOf <#Maine>.
+
+<#Maine>
+    a foaf:Person;
+    irishRel:genName "Maine";
+    irishRel:nomName "Maine";
+    rel:childOf _:missing-263ba520.
+
+_:missing-263ba520
+    a foaf:Person;
+    rel:childOf <#Ethach>.
+    #This name is illegible in the MS. - EPT
+
+<#Ethach>
+    a foaf:Person;
+    irishRel:genName "Ethach";
+    irishRel:nomName "Eochu";
+    rel:childOf <#GillaCrist>.
+    #This name is difficult to read in the MS. - EPT
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Osiab>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Osiab>
+    a foaf:Person;
+    irishRel:genName "Osiab";
+    rel:childOf <#Sainngaindrias>.
+
+<#Sainngaindrias>
+    a foaf:Person;
+    irishRel:genName "Sainngaindrias";
+    rel:childOf <#Ectigerna>.
+    #This name is difficult to read in the MS. Black suggests that it should be read
+    #as "Seanghille Ainndrias". - EPT
+
+<#Ectigerna>
+    a foaf:Person;
+    irishRel:genName "Ectigerna";
+    irishRel:nomName "Echtigern";
+    rel:childOf _:missing-01e355a0.
+    #This name is difficult to read in the MS. - EPT
+
+_:missing-01e355a0
+    a foaf:Person;
+    rel:childOf <#GillandriasMoir>.
+
+<#GillandriasMoir>
+    a foaf:Person;
+    irishRel:genName "Gillandrias Moir";
+    irishRel:nomName "Gille Andrias Mor";
+    rel:childOf <#Eittigerna>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Eittigerna>
+    a foaf:Person;
+    irishRel:genName "Eittigerna";
+    irishRel:nomName "Echthigern";
+    rel:childOf <#Ath>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Ath>
+    a foaf:Person;
+    irishRel:genName "Ath";
+    irishRel:nomName "Aed";
+    rel:childOf <#EchtigerneBetain>;
+    rdfs:comment "Cloinni Echtigerne Betain".
+    #The comment is difficult to read in the MS. - EPT
+
+<#EchtigerneBetain>
+    a foaf:Person;
+    irishRel:genName "Echtigerne Betain";
+    irishRel:nomName "Echthigern Betan";
+    rel:childOf <#Abran>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Abran>
+    a foaf:Person;
+    irishRel:genName "Abran";
+    rel:childOf <#Conaill>.
+
+<#Conaill>
+    a foaf:Person;
+    irishRel:genName "Conaill";
+    irishRel:nomName "Conall";
+    rel:childOf <#Cairbri>.
+
+<#Cairbri>
+    a foaf:Person;
+    irishRel:genName "Cairbri";
+    irishRel:nomName "Cairbre";
+    rel:childOf <#Eatach>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Eatach>
+    a foaf:Person;
+    irishRel:genName "Eatach";
+    irishRel:nomName "Eochu";
+    rel:childOf <#BethairMoir>.
+    #This name is difficult to read in the MS. Black suggests that "Eaictigerna"
+    #("Echthigern") is also a plausible reading. - EPT
+
+<#BethairMoir>
+    a foaf:Person;
+    irishRel:genName "Bethair Moir";
+    irishRel:nomName "Bethar Mor";
+    rel:childOf <#Dubgaill>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#Fergusa>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Fergusa>
+    a foaf:Person;
+    irishRel:genName "Fergusa";
+    irishRel:nomName "Fergus".
+    #This name is difficult to read in the MS. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -48,11 +48,11 @@
     a foaf:Person;
     irishRel:genName "Mhicraith";
     irishRel:nomName "Macraith";
-    rel:childOf <#Muirchertaigh>.
+    rel:childOf <#Muircertaigh>.
 
-<#Muirchertaigh>
+<#Muircertaigh>
     a foaf:Person;
-    irishRel:genName "Muirchertaigh";
+    irishRel:genName "Muircertaigh";
     irishRel:nomName "Muirchertach";
     rel:childOf <#Cormaic>.
 
@@ -89,17 +89,12 @@
     a foaf:Person;
     irishRel:genName "Maine";
     irishRel:nomName "Maine";
-    rel:childOf _:missing-263ba520.
+    rel:childOf <#Muirethaigh>.
 
-_:missing-263ba520
+<#Muirethaigh>
     a foaf:Person;
-    rel:childOf <#Ethach>.
-    #This name is illegible in the MS. - EPT
-
-<#Ethach>
-    a foaf:Person;
-    irishRel:genName "Ethach";
-    irishRel:nomName "Eochu";
+    irishRel:genName "Muirethaigh";
+    irishRel:nomName "Muiredach";
     rel:childOf <#GillaCrist>.
     #This name is difficult to read in the MS. - EPT
 
@@ -107,20 +102,10 @@ _:missing-263ba520
     a foaf:Person;
     irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
-    rel:childOf <#Osiab>.
-    #This name is difficult to read in the MS. - EPT
-
-<#Osiab>
-    a foaf:Person;
-    irishRel:genName "Osiab";
-    rel:childOf <#Sainngaindrias>.
-
-<#Sainngaindrias>
-    a foaf:Person;
-    irishRel:genName "Sainngaindrias";
+    rdfs:comment "in tris ab ar sainganndrias";
+    foaf:title "ab"@sga, "abbot"@eng;
     rel:childOf <#Ectigerna>.
-    #This name is difficult to read in the MS. Black suggests that it should be read
-    #as "Seanghille Ainndrias". - EPT
+    #The name and comment are very difficult to read in the MS. - EPT
 
 <#Ectigerna>
     a foaf:Person;
@@ -132,6 +117,7 @@ _:missing-263ba520
 _:missing-01e355a0
     a foaf:Person;
     rel:childOf <#GillandriasMoir>.
+    #This name is omitted ("mhic mhic") in the MS. - EPT
 
 <#GillandriasMoir>
     a foaf:Person;
@@ -150,62 +136,61 @@ _:missing-01e355a0
 <#Ath>
     a foaf:Person;
     irishRel:genName "Ath";
-    irishRel:nomName "Aed";
-    rel:childOf <#EchtigerneBetain>;
-    rdfs:comment "Cloinni Echtigerne Betain".
+    irishRel:nomName "Aed".
     #The comment is difficult to read in the MS. - EPT
 
-<#EchtigerneBetain>
+<#Echtigern>
     a foaf:Person;
-    irishRel:genName "Echtigerne Betain";
-    irishRel:nomName "Echthigern Betan";
-    rel:childOf <#Abran>.
+    irishRel:genName "Echtigerne";
+    irishRel:nomName "Echthigern";
+    rel:childOf <#Betain>.
     #This name is difficult to read in the MS. - EPT
 
-<#Abran>
+<#Betain>
     a foaf:Person;
-    irishRel:genName "Abran";
+    irishRel:genName "Betain";
+    rel:childOf _:missing-66a13c40.
+    #This name is difficult to read in the MS. - EPT
+
+_:missing-66a13c40
+    a foaf:Person;
+    foaf:title "an baran"@sga, "the baron"@eng;
     rel:childOf <#Conaill>.
+    #This entry is difficult to read in the MS. - EPT
 
 <#Conaill>
     a foaf:Person;
     irishRel:genName "Conaill";
     irishRel:nomName "Conall";
-    rel:childOf <#Cairbri>.
+    rel:childOf <#Cormaic-8300c3f0>.
 
-<#Cairbri>
+<#Cormaic-8300c3f0>
     a foaf:Person;
-    irishRel:genName "Cairbri";
-    irishRel:nomName "Cairbre";
-    rel:childOf <#Eatach>.
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Eachthigerna>.
     #This name is difficult to read in the MS. - EPT
 
-<#Eatach>
+<#Eachthigerna>
     a foaf:Person;
     irishRel:genName "Eatach";
     irishRel:nomName "Eochu";
-    rel:childOf <#BethairMoir>.
-    #This name is difficult to read in the MS. Black suggests that "Eaictigerna"
-    #("Echthigern") is also a plausible reading. - EPT
-
-<#BethairMoir>
-    a foaf:Person;
-    irishRel:genName "Bethair Moir";
-    irishRel:nomName "Bethar Mor";
-    rel:childOf <#Dubgaill>.
+    rel:childOf <#BeithirMoir>.
     #This name is difficult to read in the MS. - EPT
 
-<#Dubgaill>
+<#BeithirMoir>
     a foaf:Person;
-    irishRel:genName "Dubgaill";
+    irishRel:genName "Beithir Moir";
+    rel:childOf <#Dugaill>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Dugaill>
+    a foaf:Person;
+    irishRel:genName "Dugaill";
     irishRel:nomName "Dubgall";
-    rel:childOf <#Fergusa>.
-    #This name is difficult to read in the MS. - EPT
+    rdfs:comment "an fer leiginn ruadh";
+    foaf:title "fer leiginn"@sga, "lector"@eng.
+    #The name and comment are difficult to read in the MS. - EPT
 
-<#Fergusa>
-    a foaf:Person;
-    irishRel:genName "Fergusa";
-    irishRel:nomName "Fergus".
-    #This name is difficult to read in the MS. - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_18.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinni Echthigerna"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2018.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2018.html>, <https://www.1467manuscript.co.uk/MacEachernFOR%20WEB.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2018.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2018.html>, <https://www.1467manuscript.co.uk/MacEachernFOR%20WEB.pdf>.
 
 <#GillaAinndrias>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
@@ -53,21 +53,27 @@
     irishRel:genName "Mainne";
     irishRel:nomName "Maine";
     rel:childOf <#Tormoid>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Mainne>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Tormoid>
     a foaf:Person;
     irishRel:genName "Tormoid";
     irishRel:nomName "Tormod";
     rel:childOf <#ConBethad>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Tormoid>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#ConBethad>
     a foaf:Person;
     irishRel:genName "Con Bethad";
     irishRel:nomName "Cú Bethad";
     rel:childOf <#ConBethadh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#ConBethad>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Murchaidh>
     a foaf:Person;
@@ -78,8 +84,9 @@
 _:missing-d5d54720
     a foaf:Person;
     rel:childOf <#Eoghain>.
-    #This name ("t--?---") is illegible in the MS. Black suggests that "Rormoid"
-    #would fit satisfactorily. - EPT
+    << _:missing-d5d54720
+          rdfs:comment "This name ('t--?---') is illegible in the MS. Black suggests that 'Rormoid' would fit satisfactorily." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eoghain>
     a foaf:Person;
@@ -93,16 +100,18 @@ _:missing-d5d54720
     irishRel:nomName "Lamrann";
     rdfs:comment ".g.";
     rel:childOf <#Tocmoit>.
-    #This name is difficult to read in the MS. The "g" could stand for an
-    #epithet (e.g. "guirm"). - EPT
+    << <#Lamrainn>
+          rdfs:comment "This name is difficult to read in the MS. The 'g' could stand for an epithet (e.g. 'guirm')." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Tocmoit>
     a foaf:Person;
     irishRel:genName "Tocmoit";
     irishRel:nomName "Tocmot";
     rel:childOf <#Baltair>.
-    #Black suggests that this name may originally have been "Tormoid", although
-    #the "c" seems to have been written intentionally. - EPT
+    << <#Tocmoit>
+          rdfs:comment "Black suggests that this name may originally have been 'Tormoid', although the 'c' seems to have been written intentionally." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Baltair>
     a foaf:Person;
@@ -119,8 +128,8 @@ _:missing-d5d54720
 <#Ile>
     a foaf:Person;
     irishRel:genName "Ile".
-    #Black suggests that this name could be "Ailella", with the initial "i" being
-    #the back-stroke of an "a" and letters forming the last syllable being lost
-    #to the right. - EPT
+    << <#Ile>
+          rdfs:comment "Black suggests that this name could be 'Ailella', with the initial 'i' being the back-stroke of an 'a' and letters forming the last syllable being lost to the right." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Genelach Cloinni Earrain"@sga;
+    dcterms:title "Genelach Cloinni Earrainn"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2019.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2019.html> .
@@ -59,13 +59,13 @@
     a foaf:Person;
     irishRel:genName "Tormoid";
     irishRel:nomName "Tormod";
-    rel:childOf <#ConBethadh>.
+    rel:childOf <#ConBethad>.
     #This name is difficult to read in the MS. - EPT
 
-<#ConBethadh>
+<#ConBethad>
     a foaf:Person;
-    irishRel:genName "Con Bethadh";
-    irishRel:nomName "Cú Bethadh";
+    irishRel:genName "Con Bethad";
+    irishRel:nomName "Cú Bethad";
     rel:childOf <#ConBethadh>.
     #This name is difficult to read in the MS. - EPT
 
@@ -78,7 +78,8 @@
 _:missing-d5d54720
     a foaf:Person;
     rel:childOf <#Eoghain>.
-    #This name ("t--?---") is illegible in the MS. - EPT
+    #This name ("t--?---") is illegible in the MS. Black suggests that "Rormoid"
+    #would fit satisfactorily. - EPT
 
 <#Eoghain>
     a foaf:Person;
@@ -92,14 +93,16 @@ _:missing-d5d54720
     irishRel:nomName "Lamrann";
     rdfs:comment ".g.";
     rel:childOf <#Tocmoit>.
-    #This name is difficult to read in the MS. - EPT
+    #This name is difficult to read in the MS. The "g" could stand for an
+    #epithet (e.g. "guirm"). - EPT
 
 <#Tocmoit>
     a foaf:Person;
     irishRel:genName "Tocmoit";
     irishRel:nomName "Tocmot";
     rel:childOf <#Baltair>.
-    #Black suggests reading this as "Tormod". - EPT
+    #Black suggests that this name may originally have been "Tormoid", although
+    #the "c" seems to have been written intentionally. - EPT
 
 <#Baltair>
     a foaf:Person;
@@ -111,11 +114,13 @@ _:missing-d5d54720
     a foaf:Person;
     irishRel:genName "Mainne";
     irishRel:nomName "Mainne";
-    rel:childOf <#Alella>.
+    rel:childOf <#Ile>.
 
-<#Alella>
+<#Ile>
     a foaf:Person;
-    irishRel:genName "Alella";
-    irishRel:nomName "Ailill".
+    irishRel:genName "Ile".
+    #Black suggests that this name could be "Ailella", with the initial "i" being
+    #the back-stroke of an "a" and letters forming the last syllable being lost
+    #to the right. - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig
@@ -1,0 +1,121 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_19.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Earrain"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2019.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2019.html> .
+
+<#GillePadraic>
+    a foaf:Person;
+    irishRel:nomName "Gille Padraic";
+    rel:childOf <#Cormaig>.
+
+<#Cormaig>
+    a foaf:Person;
+    irishRel:genName "Cormaig";
+    irishRel:nomName "Cormac";
+    rel:childOf <#GillaPadraigeBarra>.
+
+<#GillaPadraigeBarra>
+    a foaf:Person;
+    irishRel:genName "Gilla Padraige Barra";
+    irishRel:nomName "Gilla Padraige Barra";
+    rel:childOf <#Eogainn>.
+
+<#Eogainn>
+    a foaf:Person;
+    irishRel:genName "Eogainn";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Aranilg>.
+
+<#Aranilg>
+    a foaf:Person;
+    irishRel:genName "Aranilg";
+    rel:childOf <#Mainne>.
+
+<#Mainne>
+    a foaf:Person;
+    irishRel:genName "Mainne";
+    irishRel:nomName "Maine";
+    rel:childOf <#Tormoid>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Tormoid>
+    a foaf:Person;
+    irishRel:genName "Tormoid";
+    irishRel:nomName "Tormod";
+    rel:childOf <#ConBethadh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#ConBethadh>
+    a foaf:Person;
+    irishRel:genName "Con Bethadh";
+    irishRel:nomName "Cú Bethadh";
+    rel:childOf <#ConBethadh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf _:missing-d5d54720.
+
+_:missing-d5d54720
+    a foaf:Person;
+    rel:childOf <#Eoghain>.
+    #This name ("t--?---") is illegible in the MS. - EPT
+
+<#Eoghain>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Lamrainn>.
+
+<#Lamrainn>
+    a foaf:Person;
+    irishRel:genName "Lamrainn";
+    irishRel:nomName "Lamrann";
+    rdfs:comment ".g.";
+    rel:childOf <#Tocmoit>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Tocmoit>
+    a foaf:Person;
+    irishRel:genName "Tocmoit";
+    irishRel:nomName "Tocmot";
+    rel:childOf <#Baltair>.
+    #Black suggests reading this as "Tormod". - EPT
+
+<#Baltair>
+    a foaf:Person;
+    irishRel:genName "Baltair";
+    irishRel:nomName "Baltar";
+    rel:childOf <#Mainne-a44554b0>.
+
+<#Mainne-a44554b0>
+    a foaf:Person;
+    irishRel:genName "Mainne";
+    irishRel:nomName "Mainne";
+    rel:childOf <#Alella>.
+
+<#Alella>
+    a foaf:Person;
+    irishRel:genName "Alella";
+    irishRel:nomName "Ailill".
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig
@@ -25,7 +25,9 @@
     irishRel:nomName "Maelsnechta";
     rel:childOf <#LulaighLame>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q3276323>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Maelsnechta>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#LulaighLame>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig
@@ -1,0 +1,164 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 2"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2002%20lulach.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2002%20lulach.html> .
+
+<#Maelsnechta>
+    a foaf:Person;
+    irishRel:nomName "Maelsnechta";
+    rel:childOf <#LulaighLame>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3276323>.
+    #This name is difficult to read in the MS. - EPT
+
+<#LulaighLame>
+    a foaf:Person;
+    irishRel:genName "Lulaigh Lame";
+    irishRel:nomName "Lulach Laime";
+    rel:childOf <#GillaCongmelge>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q117633>.
+
+<#GillaCongmelge>
+    a foaf:Person;
+    irishRel:genName "Gilla Congmelge";
+    irishRel:nomName "Gilla Congmelge";
+    rel:childOf <#MaoilBrigde>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3106025>.
+
+<#MaoilBrigde>
+    a foaf:Person;
+    irishRel:genName "Maoil Brigde";
+    irishRel:nomName "Maol Brigde";
+    rel:childOf <#Ruaidri>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3276310>.
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri";
+    rel:childOf <#Mornaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3446425>.
+
+<#Mornaill>
+    a foaf:Person;
+    irishRel:genName "Mornaill";
+    irishRel:nomName "Mornall";
+    rel:childOf <#Morgainn>.
+
+<#Morgainn>
+    a foaf:Person;
+    irishRel:genName "Morgainn";
+    irishRel:nomName "Morgann";
+    rel:childOf <#Domnaill>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Cathmhaeil>.
+
+<#Cathmhaeil>
+    a foaf:Person;
+    irishRel:genName "Cathmhaeil";
+    irishRel:nomName "Cathmhael";
+    rel:childOf <#Ruaidhri>.
+
+<#Ruaidhri>
+    a foaf:Person;
+    irishRel:genName "Ruaidhri";
+    irishRel:nomName "Ruaidhri";
+    rel:childOf <#Aircheallaigh>.
+
+<#Aircheallaigh>
+    a foaf:Person;
+    irishRel:genName "Aircheallaigh";
+    irishRel:nomName "Aircheallach";
+    rel:childOf <#FercairFada>.
+
+<#FercairFada>
+    a foaf:Person;
+    irishRel:genName "Fercair Fada";
+    irishRel:nomName "Fercar Fada";
+    rel:childOf <#Fearadhaigh>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q881490>.
+
+<#Fearadhaigh>
+    a foaf:Person;
+    irishRel:genName "Fearadaigh";
+    irishRel:nomName "Fearadach";
+    rel:childOf <#Fergusa>.
+
+<#Fergusa>
+    a foaf:Person;
+    irishRel:genName "Fergusa";
+    irishRel:nomName "Fergus";
+    rel:childOf <#Shneachtain>.
+
+<#Shneachtain>
+    a foaf:Person;
+    irishRel:genName "Shneachtain";
+    irishRel:nomName "Sneachtan";
+    rel:childOf <#Colmain>.
+
+<#Colmain>
+    a foaf:Person;
+    irishRel:genName "Colmain";
+    irishRel:nomName "Colman";
+    rel:childOf <#Buadain>.
+
+<#Buadain>
+    a foaf:Person;
+    irishRel:genName "Buadain";
+    irishRel:nomName "Buadan";
+    rel:childOf <#Eathhach>.
+
+<#Eathhach>
+    a foaf:Person;
+    irishRel:genName "Eathhach";
+    irishRel:nomName "Eochaid";
+    rel:childOf <#Muiredhaigh>.
+
+<#Muiredhaigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhaigh";
+    irishRel:nomName "Muiredhach";
+    rel:childOf <#LoairnMair>.
+
+<#LoairnMair>
+    a foaf:Person;
+    irishRel:genName "Loairn Mair";
+    irishRel:nomName "Loarn Már";
+    rel:childOf <#Eirc>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q951677>.
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#EthachMuinreamhair>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1270060>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig#Eirc>.
+
+<#EthachMuinreamhair>
+    a foaf:Person;
+    irishRel:genName "Ethach Muinreamhair";
+    irishRel:nomName "Eochu Muinreamhair";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig#EathachMuinnremair>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_20.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_20.trig
@@ -1,0 +1,103 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_20.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mormaeir Leamra"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2020.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2020.html> .
+
+<#Donnchadh>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Baltair>.
+
+<#Baltair>
+    a foaf:Person;
+    irishRel:genName "Baltair";
+    irishRel:nomName "Baltar";
+    rel:childOf <#Agllaoim>.
+
+<#Agllaoim>
+    a foaf:Person;
+    irishRel:genName "Agllaoim";
+    rel:childOf <#Donnchaidh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#AmlaoimOig>.
+
+<#AmlaoimOig>
+    a foaf:Person;
+    irishRel:genName "Amlaoim Oig";
+    irishRel:nomName "Amlaoim Og";
+    rel:childOf <#AmlaoimMoir>.
+
+<#AmlaoimMoir>
+    a foaf:Person;
+    irishRel:genName "Amlaoim Moir";
+    irishRel:nomName "Amlaoim Mor";
+    rel:childOf <#Muiredhgaigh>.
+
+<#Muiredhgaigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhgaigh";
+    irishRel:nomName "Muiredach";
+    rel:childOf <#MaelDomnig>.
+    #This name is difficult to read in the MS. - EPT
+
+<#MaelDomnig>
+    a foaf:Person;
+    irishRel:genName "Mael Domnig";
+    irishRel:nomName "Mael Domnig";
+    rdfs:comment "i.d.";
+    rel:childOf <#Maini>.
+    #Black transcribes the MS here as "Muiredhgaigh ar Mael Domnig", the meaning of which is unclear.
+    #As at least two Irish MSS preserve a cognate pedigree in which Muiredach is Mael Domnig's
+    #son (see https://www.1467manuscript.co.uk/kindred%2020.html), this is what it is being taken
+    #to mean. From my own examination of the manuscript, "ar" could just about be an elaborate form
+    #of "i" with a superscript "c", standing for "mic". - EPT
+
+<#Maini>
+    a foaf:Person;
+    irishRel:genName "Maini";
+    irishRel:nomName "Maine";
+    rel:childOf <#Cuirc>.
+
+<#Cuirc>
+    a foaf:Person;
+    irishRel:genName "Cuirc";
+    irishRel:nomName "Corc";
+    rel:childOf <#Luigdheach>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Luigdheach>
+    a foaf:Person;
+    irishRel:genName "Luigdech";
+    irishRel:nomName "Lugaid";
+    rel:childOf <#Cairil>.
+
+<#Cairil>
+    a foaf:Person;
+    irishRel:genName "Cairil";
+    irishRel:nomName "Cairell".
+    #Approximately 6 more names appear in the pedigree, for which Black provides some possible readings.
+    #However, these are so hypothetical, and the manuscript itself so difficult to make out, that I did
+    #not feel able to include anything beyond this point. - EPT
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_20.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_20.trig
@@ -35,7 +35,9 @@
     a foaf:Person;
     irishRel:genName "Agllaoim";
     rel:childOf <#Donnchaidh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Agllaoim>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Donnchaidh>
     a foaf:Person;
@@ -60,7 +62,9 @@
     irishRel:genName "Muiredhgaigh";
     irishRel:nomName "Muiredach";
     rel:childOf <#MaelDomnig>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Muiredhgaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#MaelDomnig>
     a foaf:Person;
@@ -68,11 +72,9 @@
     irishRel:nomName "Mael Domnig";
     rdfs:comment "i.d.";
     rel:childOf <#Maini>.
-    #Black transcribes the MS here as "Muiredhgaigh ar Mael Domnig", the meaning of which is unclear.
-    #As at least two Irish MSS preserve a cognate pedigree in which Muiredach is Mael Domnig's
-    #son (see https://www.1467manuscript.co.uk/kindred%2020.html), this is what it is being taken
-    #to mean. From my own examination of the manuscript, "ar" could just about be an elaborate form
-    #of "i" with a superscript "c", standing for "mic". - EPT
+    << <#MaelDomnig>
+          rdfs:comment "Black transcribes the MS here as 'Muiredhgaigh ar Mael Domnig', the meaning of which is unclear. As at least two Irish MSS preserve a cognate pedigree in which Muiredach is Mael Domnig's son (see https://www.1467manuscript.co.uk/kindred%2020.html), this is what it is being taken to mean. From my own examination of the manuscript, 'ar' could just about be an elaborate form of 'i' with a superscript 'c', standing for 'mic'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Maini>
     a foaf:Person;
@@ -85,7 +87,9 @@
     irishRel:genName "Cuirc";
     irishRel:nomName "Corc";
     rel:childOf <#Luigdheach>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Cuirc>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Luigdheach>
     a foaf:Person;
@@ -97,7 +101,7 @@
     a foaf:Person;
     irishRel:genName "Cairil";
     irishRel:nomName "Cairell".
-    #Approximately 6 more names appear in the pedigree, for which Black provides some possible readings.
-    #However, these are so hypothetical, and the manuscript itself so difficult to make out, that I did
-    #not feel able to include anything beyond this point. - EPT
+    << <#Cairil>
+          rdfs:comment "Approximately 6 more names appear in the pedigree, for which Black provides some possible readings. However, these are so hypothetical, and the manuscript itself so difficult to make out, that I did not feel able to include anything beyond this point." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelaigh Cloinni Ladmainn"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2021.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2021.html>, <https://www.1467manuscript.co.uk/lamont.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2021.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2021.html>, <https://www.1467manuscript.co.uk/lamont.pdf>.
 
 <#Raiberd>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Genelach Cloinni Ladmainn"@sga;
+    dcterms:title "Genelaigh Cloinni Ladmainn"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2021.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2021.html> .
@@ -42,22 +42,22 @@
     a foaf:Person;
     irishRel:genName "Gilla Colaim";
     irishRel:nomName "Gilla Colaim";
-    rel:childOf <#Ladmainn>.
+    rel:childOf <#Ladhmainn>.
 
-<#Ladmainn>
+<#Ladhmainn>
     a foaf:Person;
-    irishRel:genName "Ladmainn";
-    irishRel:nomName "Ladmann";
-    rel:childOf <#Gillaspaig>;
+    irishRel:genName "Ladhmainn";
+    irishRel:nomName "Ladhmann";
+    rel:childOf <#GillaCholaim>;
     rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/3204>.
     #This name is difficult to read in the MS. - EPT
 
-<#Gillaspaig>
+<#GillaCholaim>
     a foaf:Person;
-    irishRel:genName "Gillaspaig";
-    irishRel:nomName "Gilla Espaig";
+    irishRel:genName "Gilla Cholaim";
+    irishRel:nomName "Gilla Colaim";
     rel:childOf <#Ferchair>.
-    #This name seems to have been written in over "Gilla Colaim". - EPT
+    #This name is difficult to read in the MS. - EPT
 
 <#Ferchair>
     a foaf:Person;
@@ -70,77 +70,68 @@
     a foaf:Person;
     irishRel:genName "Duinn tSleibe";
     irishRel:nomName "Donn Sleibe";
-    rel:childOf <#AedAlainn>.
+    rel:childOf <#Aeda>.
     #This name is difficult to read in the MS. - EPT
 
-<#AedAlainn>
+<#Aeda>
     a foaf:Person;
-    irishRel:genName "Aed Alainn";
-    irishRel:nomName "Aed Alainn";
+    irishRel:genName "Aeda";
+    irishRel:nomName "Aed";
     rdfs:comment ".i. buirce";
-    rel:childOf <#Anradain>.
+    rel:childOf <#Anradhain>.
     #This name is difficult to read in the MS. - EPT
 
-<#Anradain>
+<#Anradhain>
     a foaf:Person;
-    irishRel:genName "Anradain";
-    irishRel:nomName "Anradan";
-    rel:childOf <#Flaitbertaig>.
+    irishRel:genName "Anradhain";
+    irishRel:nomName "Anradhan";
+    rel:childOf <#Fleitbertaig>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q76048219>.
 
-<#Flaitbertaig>
+<#Fleitbertaig>
     a foaf:Person;
-    irishRel:genName "Flaitbertaig";
+    irishRel:genName "Fleitbertaig";
     irishRel:nomName "Flaithbertach";
-    rel:childOf <#Connstantin>.
+    rdfs:comment "in Trosdan";
+    rel:childOf <#Muircertaig>;
+    rdfs:seeAlso <#https://www.wikidata.org/entity/Q3073239>.
     #This name is difficult to read in the MS. - EPT
 
-<#Connstantin>
+<#Muircertaig>
     a foaf:Person;
-    irishRel:genName "Connstantin";
-    irishRel:nomName "Connstantin";
-    rel:childOf <#Muiredhaigh>.
+    irishRel:genName "Muircertaig";
+    irishRel:nomName "Muirchertach";
+    rdfs:comment "Mighig";
+    rel:childOf <#Domnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75675831>.
     #This name is difficult to read in the MS. - EPT
-
-<#Muiredhaigh>
-    a foaf:Person;
-    irishRel:genName "Muiredhaigh";
-    irishRel:nomName "Muiredhach";
-    rel:childOf _:missing-cdc6a200.
-    #This name is difficult to read in the MS. - EPT
-
-_:missing-cdc6a200
-    a foaf:Person;
-    rel:childOf <#Domnaill>.
-    #The MS is illegible at this point; the space is enough for "mhic" and then a
-    #short name. - EPT
 
 <#Domnaill>
     a foaf:Person;
     irishRel:genName "Domnaill";
     irishRel:nomName "Domnall";
-    rel:childOf <#GillaCrist>.
-
-<#GillaCrist>
-    a foaf:Person;
-    irishRel:genName "Gilla Crist";
-    irishRel:nomName "Gilla Crist";
-    rel:childOf <#Murachaidh>.
-    #This name is difficult to read in the MS. - EPT
+    rel:childOf <#Murachaidh>;
+    rdfs:comment "Arda Mhachad";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1152971>.
+    #The epithet ("Arda Mhachad") is badly distorted and Black suggests that it was
+    #subsequently altered to resemble another generation in the pedigree ("mhic damhachad"). - EPT
 
 <#Murachaidh>
     a foaf:Person;
     irishRel:genName "Murachaidh";
     irishRel:nomName "Murachadh";
-    rdfs:comment ".i. Gilla Dub";
-    rel:childOf <#NeillGlunduibh>.
-    #This name and the note are difficult to read in the MS. - EPT
+    rdfs:comment "na cCochaill gCroicend";
+    rel:childOf <#NeillGlunduibh>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q733929>.
+    #This name and epithet are difficult to read in the MS. - EPT
 
 <#NeillGlunduibh>
     a foaf:Person;
     irishRel:genName "Neill Glunduibh";
     irishRel:nomName "Niall Glundubh";
     rdfs:comment "ite";
-    owl:sameAs <http://example.com/Rawl_B502/haec_sunt_credentium_nomina.trig#NiallGlúndub>.
+    owl:sameAs <http://example.com/Rawl_B502/haec_sunt_credentium_nomina.trig#NiallGlúndub>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1274033>.
     #This name and the note are difficult to read in the MS. Black's reading is based on cognate
     #pedigrees in Irish MSS. - EPT
 

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
@@ -1,0 +1,139 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Ladmainn"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2021.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2021.html> .
+
+<#Raiberd>
+    a foaf:Person;
+    irishRel:nomName "Raiberd";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#GillaColaim>.
+
+<#GillaColaim>
+    a foaf:Person;
+    irishRel:genName "Gilla Colaim";
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#Ladmainn>.
+
+<#Ladmainn>
+    a foaf:Person;
+    irishRel:genName "Ladmainn";
+    irishRel:nomName "Ladmann";
+    rel:childOf <#Gillaspaig>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Gillaspaig>
+    a foaf:Person;
+    irishRel:genName "Gillaspaig";
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Ferchair>.
+    #This name seems to have been written in over "Gilla Colaim". - EPT
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Duinntsleibe>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Duinntsleibe>
+    a foaf:Person;
+    irishRel:genName "Duinn tSleibe";
+    irishRel:nomName "Donn Sleibe";
+    rel:childOf <#AedAlainn>.
+    #This name is difficult to read in the MS. - EPT
+
+<#AedAlainn>
+    a foaf:Person;
+    irishRel:genName "Aed Alainn";
+    irishRel:nomName "Aed Alainn";
+    rdfs:comment ".i. buirce";
+    rel:childOf <#Anradain>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Anradain>
+    a foaf:Person;
+    irishRel:genName "Anradain";
+    irishRel:nomName "Anradan";
+    rel:childOf <#Flaitbertaig>.
+
+<#Flaitbertaig>
+    a foaf:Person;
+    irishRel:genName "Flaitbertaig";
+    irishRel:nomName "Flaithbertach";
+    rel:childOf <#Connstantin>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Connstantin>
+    a foaf:Person;
+    irishRel:genName "Connstantin";
+    irishRel:nomName "Connstantin";
+    rel:childOf <#Muiredhaigh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Muiredhaigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhaigh";
+    irishRel:nomName "Muiredhach";
+    rel:childOf _:missing-cdc6a200.
+    #This name is difficult to read in the MS. - EPT
+
+_:missing-cdc6a200
+    a foaf:Person;
+    rel:childOf <#Domnaill>.
+    #The MS is illegible at this point; the space is enough for "mhic" and then a
+    #short name. - EPT
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Murachaidh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Murachaidh>
+    a foaf:Person;
+    irishRel:genName "Murachaidh";
+    irishRel:nomName "Murachadh";
+    rdfs:comment ".i. Gilla Dub";
+    rel:childOf <#NeillGlunduibh>.
+    #This name and the note are difficult to read in the MS. - EPT
+
+<#NeillGlunduibh>
+    a foaf:Person;
+    irishRel:genName "Neill Glunduibh";
+    irishRel:nomName "Niall Glundubh";
+    rdfs:comment "ite";
+    owl:sameAs <http://example.com/Rawl_B502/haec_sunt_credentium_nomina.trig#NiallGlúndub>.
+    #This name and the note are difficult to read in the MS. Black's reading is based on cognate
+    #pedigrees in Irish MSS. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
@@ -50,28 +50,36 @@
     irishRel:nomName "Ladhmann";
     rel:childOf <#GillaCholaim>;
     rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/3204>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Ladhmainn>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCholaim>
     a foaf:Person;
     irishRel:genName "Gilla Cholaim";
     irishRel:nomName "Gilla Colaim";
     rel:childOf <#Ferchair>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaCholaim>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ferchair>
     a foaf:Person;
     irishRel:genName "Ferchair";
     irishRel:nomName "Ferchar";
     rel:childOf <#Duinntsleibe>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Ferchair>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Duinntsleibe>
     a foaf:Person;
     irishRel:genName "Duinn tSleibe";
     irishRel:nomName "Donn Sleibe";
     rel:childOf <#Aeda>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Duinntsleibe>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Aeda>
     a foaf:Person;
@@ -79,7 +87,9 @@
     irishRel:nomName "Aed";
     rdfs:comment ".i. buirce";
     rel:childOf <#Anradhain>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Aeda>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Anradhain>
     a foaf:Person;
@@ -95,7 +105,9 @@
     rdfs:comment "in Trosdan";
     rel:childOf <#Muircertaig>;
     rdfs:seeAlso <#https://www.wikidata.org/entity/Q3073239>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Fleitbertaig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Muircertaig>
     a foaf:Person;
@@ -104,7 +116,9 @@
     rdfs:comment "Mighig";
     rel:childOf <#Domnaill>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q75675831>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Muircertaig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Domnaill>
     a foaf:Person;
@@ -113,8 +127,9 @@
     rel:childOf <#Murachaidh>;
     rdfs:comment "Arda Mhachad";
     rdfs:seeAlso <https://www.wikidata.org/entity/Q1152971>.
-    #The epithet ("Arda Mhachad") is badly distorted and Black suggests that it was
-    #subsequently altered to resemble another generation in the pedigree ("mhic damhachad"). - EPT
+    << <#Domnaill>
+          rdfs:comment "The epithet ('Arda Mhachad') is badly distorted and Black suggests that it was subsequently altered to resemble another generation in the pedigree ('mhic damhachad')." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Murachaidh>
     a foaf:Person;
@@ -123,7 +138,9 @@
     rdfs:comment "na cCochaill gCroicend";
     rel:childOf <#NeillGlunduibh>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q733929>.
-    #This name and epithet are difficult to read in the MS. - EPT
+    << <#Murachaidh>
+          rdfs:comment "This name and epithet are difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#NeillGlunduibh>
     a foaf:Person;
@@ -132,7 +149,8 @@
     rdfs:comment "ite";
     owl:sameAs <http://example.com/Rawl_B502/haec_sunt_credentium_nomina.trig#NiallGlúndub>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q1274033>.
-    #This name and the note are difficult to read in the MS. Black's reading is based on cognate
-    #pedigrees in Irish MSS. - EPT
+    << <#NeillGlunduibh>
+          rdfs:comment "This name and the note are difficult to read in the MS. Black's reading is based on cognate pedigrees in Irish MSS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_21.trig
@@ -27,9 +27,16 @@
 
 <#Donnchaidh>
     a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
     irishRel:genName "Eoin";
     irishRel:nomName "Eoin";
-    rel:childOf <#GillaColaim>.
+    rel:childOf <#GillaColaim>;
+    rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/17672>.
 
 <#GillaColaim>
     a foaf:Person;
@@ -41,7 +48,8 @@
     a foaf:Person;
     irishRel:genName "Ladmainn";
     irishRel:nomName "Ladmann";
-    rel:childOf <#Gillaspaig>.
+    rel:childOf <#Gillaspaig>;
+    rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/3204>.
     #This name is difficult to read in the MS. - EPT
 
 <#Gillaspaig>

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
@@ -24,21 +24,27 @@
     a foaf:Person;
     irishRel:nomName "Gilla Colaim Og";
     rel:childOf <#GillaColaimMoir>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaColaimOg>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaColaimMhoir>
     a foaf:Person;
     irishRel:genName "Gilla Colaim Mhoir";
     irishRel:nomName "Gilla Colaim Mor";
     rel:childOf <#MaelMuire>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaColaimMhoir>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#MaelMuire>
     a foaf:Person;
     irishRel:genName "Mael Muire";
     irishRel:nomName "Mael Muire";
     rel:childOf <#Cainnig>.
-    #This name is difficult to read in the MS. - EPT
+    << <#MaelMuire>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Cainnig>
     a foaf:Person;
@@ -51,10 +57,9 @@
     irishRel:genName "Dubgaill";
     irishRel:nomName "Dubgall";
     rel:childOf <#GillaColaim>.
-    #This name is difficult to read in the MS; Black suggests that it could have
-    #been amended from "Dubgaill", which is the reading in the cognate
-    #pedigree in Mac Firbhisigh, to "Gila Maeil" by an unidentified hand that interferes
-    # a number of times in the text. - EPT
+    << <#Dubgaill>
+          rdfs:comment "This name is difficult to read in the MS; Black suggests that it could have been amended from 'Dubgaill', which is the reading in the cognate pedigree in Mac Firbhisigh, to 'Gila Maeil' by an unidentified hand that interferes a number of times in the text." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
  <#GillaColaim>
     a foaf:Person;
@@ -69,7 +74,9 @@
     irishRel:nomName "in Gilla Maeil";
     rdfs:comment "dar comainm in Gilla Maeil";
     rel:childOf <#Cormaic>.
-    #The name and comment are difficult to read in the MS. - EPT
+    << <#GillCriost>
+          rdfs:comment "The name and comment are difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Cormaic>
     a foaf:Person;
@@ -83,6 +90,8 @@
     irishRel:genName "Airbertaigh";
     irishRel:nomName "Airbertach";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
-    #The name and comment are difficult to read in the MS. - EPT
+    << <#Airbertaigh>
+          rdfs:comment "The name and comment are difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
@@ -20,14 +20,15 @@
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2022.html> .
 
-<#GillaColaim>
+<#GillaColaimOg>
     a foaf:Person;
-    irishRel:nomName "Gilla Colaim";
+    irishRel:nomName "Gilla Colaim Og";
     rel:childOf <#GillaColaimMoir>.
+    #This name is difficult to read in the MS. - EPT
 
-<#GillaColaimMoir>
+<#GillaColaimMhoir>
     a foaf:Person;
-    irishRel:genName "Gilla Colaim Moir";
+    irishRel:genName "Gilla Colaim Mhoir";
     irishRel:nomName "Gilla Colaim Mor";
     rel:childOf <#MaelMuire>.
     #This name is difficult to read in the MS. - EPT
@@ -43,22 +44,28 @@
     a foaf:Person;
     irishRel:genName "Cainnig";
     irishRel:nomName "Cainnech";
-    rel:childOf <#GilaMaeilOig>.
+    rel:childOf <#Dubgaill>.
 
-<#GilaMaeilOig>
+<#Dubgaill>
     a foaf:Person;
-    irishRel:genName "Gilla Maeil Oig";
-    irishRel:nomName "Gilla Maeil Og";
-    rel:childOf <#GillCrist>.
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#GillaColaim>.
     #This name is difficult to read in the MS; Black suggests that it could have
-    #been amended to or from "Dubgaill", which is the reading in the cognate
-    #pedigree in Mac Firbhisigh. Mac Firbhisigh's version also includes an extra
-    #generation "mhic Gilla Colaim". - EPT
+    #been amended from "Dubgaill", which is the reading in the cognate
+    #pedigree in Mac Firbhisigh, to "Gila Maeil" by an unidentified hand that interferes
+    # a number of times in the text. - EPT
 
-<#GillCrist>
+ <#GillaColaim>
     a foaf:Person;
-    irishRel:genName "Gill Crist";
-    irishRel:nomName "Gill Crist";
+    irishRel:genName "Gilla Colaim";
+    irishRel:nomname "Gilla Colaim";
+    rel:childOf <#GillCriost>.
+
+<#GillCriost>
+    a foaf:Person;
+    irishRel:genName "Gill Criost";
+    irishRel:nomName "Gill Criost";
     irishRel:nomName "in Gilla Maeil";
     rdfs:comment "dar comainm in Gilla Maeil";
     rel:childOf <#Cormaic>.

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Mhic Gilla Maeil"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2022.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2022.html>, <https://www.1467manuscript.co.uk/MacMillan%20FOR%20WEB.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2022.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2022.html>, <https://www.1467manuscript.co.uk/MacMillan%20FOR%20WEB.pdf>.
 
 <#GillaColaimOg>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig
@@ -1,0 +1,81 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_22.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Gilla Maeil"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2022.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2022.html> .
+
+<#GillaColaim>
+    a foaf:Person;
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#GillaColaimMoir>.
+
+<#GillaColaimMoir>
+    a foaf:Person;
+    irishRel:genName "Gilla Colaim Moir";
+    irishRel:nomName "Gilla Colaim Mor";
+    rel:childOf <#MaelMuire>.
+    #This name is difficult to read in the MS. - EPT
+
+<#MaelMuire>
+    a foaf:Person;
+    irishRel:genName "Mael Muire";
+    irishRel:nomName "Mael Muire";
+    rel:childOf <#Cainnig>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Cainnig>
+    a foaf:Person;
+    irishRel:genName "Cainnig";
+    irishRel:nomName "Cainnech";
+    rel:childOf <#GilaMaeilOig>.
+
+<#GilaMaeilOig>
+    a foaf:Person;
+    irishRel:genName "Gilla Maeil Oig";
+    irishRel:nomName "Gilla Maeil Og";
+    rel:childOf <#GillCrist>.
+    #This name is difficult to read in the MS; Black suggests that it could have
+    #been amended to or from "Dubgaill", which is the reading in the cognate
+    #pedigree in Mac Firbhisigh. Mac Firbhisigh's version also includes an extra
+    #generation "mhic Gilla Colaim". - EPT
+
+<#GillCrist>
+    a foaf:Person;
+    irishRel:genName "Gill Crist";
+    irishRel:nomName "Gill Crist";
+    irishRel:nomName "in Gilla Maeil";
+    rdfs:comment "dar comainm in Gilla Maeil";
+    rel:childOf <#Cormaic>.
+    #The name and comment are difficult to read in the MS. - EPT
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Cormaic>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
+    #The name and comment are difficult to read in the MS. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_23.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_23.trig
@@ -1,0 +1,97 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_23.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Gabharain Erca"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2023.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2023.html> .
+
+<#Murchadh>
+    a foaf:Person;
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Coll>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Coll>
+    a foaf:Person;
+    irishRel:genName "Coll";
+    rel:childOf _:missing-a7d906e0.
+    #This name is difficult to read in the MS. - EPT
+
+_:missing-a7d906e0
+    a foaf:Person;
+    rel:childOf <#Murchaidh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#FerchairMor>.
+
+<#FerchairMor>
+    a foaf:Person;
+    irishRel:genName "Ferchair Mor";
+    irishRel:nomName "Ferchar Mor";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf _:missing-17638fd0.
+
+_:missing-17638fd0
+    a foaf:Person;
+    rel:childOf <#GillaaganMor>.
+    #This name is illegible in the manuscript. - EPT
+
+<#GillaaganMor>
+    a foaf:Person;
+    irishRel:genName "Gillaagan Mor";
+    rdfs:comment "o fuilid";
+    rel:childOf <#Cormaic>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Cormaic>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradhach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Ferchairdi>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_23.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_23.trig
@@ -30,13 +30,17 @@
     irishRel:genName "Ferchair";
     irishRel:nomName "Ferchar";
     rel:childOf <#Coll>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Ferchair>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Coll>
     a foaf:Person;
     irishRel:genName "Coll";
     rel:childOf _:missing-a7d906e0.
-    #This name is difficult to read in the MS. - EPT
+    << <#Coll>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-a7d906e0
     a foaf:Person;
@@ -63,14 +67,18 @@ _:missing-a7d906e0
 _:missing-17638fd0
     a foaf:Person;
     rel:childOf <#GillaaganMor>.
-    #This name is illegible in the manuscript. - EPT
+    << _:missing-17638fd0
+          rdfs:comment "This name is illegible in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaaganMor>
     a foaf:Person;
     irishRel:genName "Gillaagan Mor";
     rdfs:comment "o fuilid";
     rel:childOf <#Cormaic>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaaganMor>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Cormaic>
     a foaf:Person;
@@ -78,7 +86,9 @@ _:missing-17638fd0
     irishRel:nomName "Cormac";
     rel:childOf <#Airbertaigh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Cormaic>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Cormaic>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Airbertaigh>
     a foaf:Person;
@@ -86,7 +96,9 @@ _:missing-17638fd0
     irishRel:nomName "Airbertach";
     rel:childOf <#Feradhaigh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig#Airbertaigh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Airbertaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Feradhaigh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -71,7 +72,7 @@
     rel:childOf <#ConDuiligh>.
 
 <#ConDuiligh>
-    a IrishTitles:Abb;
+    a IrishTitle:Abb;
     irishRel:genName "Con Duiligh";
     irishRel:nomName "Cu Duiligh";
     rdfs:comment "ab Lesa Mor sanab I";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -172,8 +172,7 @@ _:missing-d8b35630
 
 <#Egac>
     a foaf:Person;
-    irishRel:genName "Egach";
-    irishRel:nomName "Eochu".
+    irishRel:genName "Egac".
     #This name is difficult to read in the MS. Black reads "cgac" and takes this as
     #a corruption of "Echach" (genitive of Eochu). I am prepared to read the first
     #"c" as "e". Black suggests that this is Eochaidh Muinreamhair, on account of his

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Do Genilach Cloinni Gil Eain"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2024.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2024.html>, <https://www.1467manuscript.co.uk/Maclean.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2024.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2024.html>, <https://www.1467manuscript.co.uk/Maclean.pdf>.
 
 <#Laclain>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -36,7 +36,9 @@
     irishRel:genName "Gille Colaim";
     irishRel:nomName "Gilla Colaim";
     rel:childOf <#MaeilIsog>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GilleColaim>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#MaeilIsog>
     a foaf:Person;
@@ -81,7 +83,9 @@
     irishRel:genName "Raing Ruaidh";
     irishRel:nomName "Rang Ruadh";
     rel:childOf <#SanDubgaill>.
-    #This name is difficult to read in the MS. - EPT
+    << <#RaingRuaidh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#SenDubgaill>
     a foaf:Person;
@@ -89,10 +93,9 @@
     irishRel:nomName "Seandubgall";
     rdfs:comment "a lis";
     rel:childOf <#FherchairAbradraidh>.
-    #Black remarks that the comment "a lis" can be taken as "a[n] lis" (of the monastic garden) or
-    #as "a Lis" (from Lismore). Other MSS have "Sgoinne" (of Scone) at this point, which is only
-    #compatible with the first reading, unless SeanDubghall moved between monasteries in the
-    #course of his career. - EPT
+    << <#SenDubgaill>
+          rdfs:comment "Black remarks that the comment 'a lis' can be taken as 'a[n] lis' (of the monastic garden) or as 'a Lis' (from Lismore). Other MSS have 'Sgoinne' (of Scone) at this point, which is only compatible with the first reading, unless SeanDubghall moved between monasteries in the course of his career." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#FherchairAbradruaidh>
     a foaf:Person;
@@ -100,7 +103,9 @@
     irishRel:nomName "Ferchar Abradruadh";
     rel:childOf <#Feradhaigh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig#FerchairAbradruadh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#FherchairAbradruaidh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Feradhaigh>
     a foaf:Person;
@@ -115,8 +120,9 @@
     irishRel:nomName "Fergus";
     rel:childOf <#Nechtain>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fergusa>.
-    #This name is illegible in the MS, although the preceding "mhic" can be read;
-    #Black derives it mainly from readings in other MSS. - EPT
+    << <#Fergusa>
+          rdfs:comment "This name is illegible in the MS, although the preceding 'mhic' can be read; Black derives it mainly from readings in other MSS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Nechtain>
     a foaf:Person;
@@ -138,10 +144,9 @@
     irishRel:nomName "Leatan";
     rdfs:comment ".i. [...]";
     rel:childOf <#Morgainn>.
-    #A comment has been added after this name, but, beyond the "ed ón" abbreviation,
-    #it is now illegible. The name Buadan appears in the equivalent location in Kindred
-    #2. Black suggests it has been adapted here to create another ancestor-figure for the
-    #MacLeans (i.e. the Leathanaich). - EPT
+    << <#Leatain>
+          rdfs:comment "A comment has been added after this name, but, beyond the 'ed ón' abbreviation, it is now illegible. The name Buadan appears in the equivalent location in Kindred 2. Black suggests it has been adapted here to create another ancestor-figure for the MacLeans (i.e. the Leathanaich)." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Morgainn>
     a foaf:Person;
@@ -170,24 +175,23 @@
     irishRel:nomName "Ruaidri";
     rel:childOf _:missing-d8b35630;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Ruaidhri>.
-    #This name is illegible in the MS; Black seems to derive it mainly
-    #from readings in other MSS. - EPT
+    << <#Ruaidri>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-d8b35630
     a foaf:Person;
     rel:childOf <#Egac>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Aircheallaigh>.
-    #This name is partly illegible in the MS "[...]rullaigh"; Black takes it as
-    #a form of "Aircheallach". - EPT
+    << _:missing-d8b35630
+          rdfs:comment "This name is partly illegible in the MS '[...]rullaigh'; Black takes it as a form of 'Aircheallach'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Egac>
     a foaf:Person;
     irishRel:genName "Egac".
-    #This name is difficult to read in the MS. Black reads "cgac" and takes this as
-    #a corruption of "Echach" (genitive of Eochu). I am prepared to read the first
-    #"c" as "e". Black suggests that this is Eochaidh Muinreamhair, on account of his
-    #appearance in the MacLean pedigree in other MSS. However, in these other MSS,
-    #Eochaidh Muinreamhair appears in a different context within the pedigree. This
-    #identification thus does not seem justified. - EPT
+    << <#Egac>
+          rdfs:comment "This name is difficult to read in the MS. Black reads 'cgac' and takes this as a corruption of 'Echach' (genitive of Eochu). I am prepared to read the first 'c' as 'e'. Black suggests that this is Eochaidh Muinreamhair, on account of his appearance in the MacLean pedigree in other MSS. However, in these other MSS, Eochaidh Muinreamhair appears in a different context within the pedigree. This identification thus does not seem justified." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Do Genelach Cloinni Gil Eain"@sga;
+    dcterms:title "Do Genilach Cloinni Gil Eain"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2024.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2024.html> .
@@ -35,24 +35,24 @@
     a foaf:Person;
     irishRel:genName "Gille Colaim";
     irishRel:nomName "Gilla Colaim";
-    rel:childOf <#Maulisog>.
+    rel:childOf <#MaeilIsog>.
     #This name is difficult to read in the MS. - EPT
 
-<#Maulisog>
+<#MaeilIsog>
     a foaf:Person;
-    irishRel:genName "Maulisog";
-    irishRel:nomName "Maol Ísóg";
+    irishRel:genName "Maeil Isog";
+    irishRel:nomName "Mael Isog";
     rel:childOf <#GillaEoin>.
 
 <#GillaEoin>
     a foaf:Person;
     irishRel:genName "Gilla Eoin";
     irishRel:nomName "Gilla Eoin";
-    rel:childOf <#Mhicrait>.
+    rel:childOf <#MhicRait>.
 
-<#Mhicrait>
+<#MhicRait>
     a foaf:Person;
-    irishRel:genName "Mhicrait";
+    irishRel:genName "Mhic Rait";
     irishRel:nomName "Mac Raith";
     rel:childOf <#Suthain>.
 
@@ -66,13 +66,13 @@
     a foaf:Person;
     irishRel:genName "Neill";
     irishRel:nomName "Niall";
-    rel:childOf <#Conduiligh>.
+    rel:childOf <#ConDuiligh>.
 
-<#Conduiligh>
+<#ConDuiligh>
     a foaf:Person;
     irishRel:genName "Con Duiligh";
     irishRel:nomName "Cu Duiligh";
-    rdfs:comment "ab Lesa Mor sanabi";
+    rdfs:comment "ab Lesa Mor sanab I";
     foaf:title "ab"@sga, "abbot"@eng;
     rel:childOf <#RaingRuaidh>.
 
@@ -80,56 +80,68 @@
     a foaf:Person;
     irishRel:genName "Raing Ruaidh";
     irishRel:nomName "Rang Ruadh";
-    rel:childOf <#Seandubgaill>.
+    rel:childOf <#SanDubgaill>.
     #This name is difficult to read in the MS. - EPT
 
-<#Seandubgaill>
+<#SenDubgaill>
     a foaf:Person;
     irishRel:genName "Seandubgaill";
     irishRel:nomName "Seandubgall";
-    rdfs:comment "ar lss";
+    rdfs:comment "a lis";
     rel:childOf <#FherchairAbradraidh>.
-    #This name is abbreviated to "sean dubg" in the MS. Black takes "ar lss" to
-    #be a corruption of "Sgoinne" (of Scone). - EPT
+    #Black remarks that the comment "a lis" can be taken as "a[n] lis" (of the monastic garden) or
+    #as "a Lis" (from Lismore). Other MSS have "Sgoinne" (of Scone) at this point, which is only
+    #compatible with the first reading, unless SeanDubghall moved between monasteries in the
+    #course of his career. - EPT
 
 <#FherchairAbradruaidh>
     a foaf:Person;
     irishRel:genName "Fherchair Abradruaidh";
     irishRel:nomName "Ferchar Abradruadh";
-    rel:childOf <#Feradhaigh>.
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig#FerchairAbradruadh>.
     #This name is difficult to read in the MS. - EPT
 
 <#Feradhaigh>
     a foaf:Person;
     irishRel:genName "Feradhaigh";
     irishRel:nomName "Feradhach";
-    rel:childOf <#Fergusa>.
+    rel:childOf <#Fergusa>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
 
 <#Fergusa>
     a foaf:Person;
     irishRel:genName "Fergusa";
     irishRel:nomName "Fergus";
-    rel:childOf <#Nechtain>.
-    #This name is illegible in the MS; Black seems to derive it mainly
-    #from readings in other MSS. - EPT
+    rel:childOf <#Nechtain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fergusa>.
+    #This name is illegible in the MS, although the preceding "mhic" can be read;
+    #Black derives it mainly from readings in other MSS. - EPT
 
 <#Nechtain>
     a foaf:Person;
     irishRel:genName "Nechtain";
     irishRel:nomName "Nechtan";
-    rel:childOf <#Colmain>.
+    rel:childOf <#Colmain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Shneachtain>.
 
 <#Colmain>
     a foaf:Person;
     irishRel:genName "Colmain";
     irishRel:nomName "Colman";
-    rel:childOf <#Leatain>.
+    rel:childOf <#Leatain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Colmain>.
 
 <#Leatain>
     a foaf:Person;
     irishRel:genName "Leatain";
     irishRel:nomName "Leatan";
+    rdfs:comment ".i. [...]"
     rel:childOf <#Morgainn>.
+    #A comment has been added after this name, but, beyond the "ed ón" abbreviation,
+    #it is now illegible. The name Buadan appears in the equivalent location in Kindred
+    #2. Black suggests it has been adapted here to create another ancestor-figure for the
+    #MacLeans (i.e. the Leathanaich). - EPT
 
 <#Morgainn>
     a foaf:Person;
@@ -142,15 +154,13 @@
     a foaf:Person;
     irishRel:genName "Domhnaill";
     irishRel:nomName "Domhnall";
-    rel:childOf <#Cathmael>;
+    rel:childOf <#Cathmhael>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Domnaill>.
-    #This name is illegible in the MS; Black seems to derive it mainly
-    #from readings in other MSS. - EPT
 
-<#Cathmael>
+<#Cathmhael>
     a foaf:Person;
-    irishRel:genName "Cathmael";
-    irishRel:nomName "Cathmael";
+    irishRel:genName "Cathmhael";
+    irishRel:nomName "Cathmhael";
     rel:childOf <#Ruaidri>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Cathmhaeil>.
 

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -1,0 +1,181 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Do Genelach Cloinni Gil Eain"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2024.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2024.html> .
+
+<#Laclain>
+    a foaf:Person;
+    irishRel:nomName "Laclain";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#GilleColaim>.
+
+<#GilleColaim>
+    a foaf:Person;
+    irishRel:genName "Gille Colaim";
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#Maulisog>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Maulisog>
+    a foaf:Person;
+    irishRel:genName "Maulisog";
+    irishRel:nomName "Maol Ísóg";
+    rel:childOf <#GillaEoin>.
+
+<#GillaEoin>
+    a foaf:Person;
+    irishRel:genName "Gilla Eoin";
+    irishRel:nomName "Gilla Eoin";
+    rel:childOf <#Mhicrait>.
+
+<#Mhicrait>
+    a foaf:Person;
+    irishRel:genName "Mhicrait";
+    irishRel:nomName "Mac Raith";
+    rel:childOf <#Suthain>.
+
+<#Suthain>
+    a foaf:Person;
+    irishRel:genName "Suthain";
+    irishRel:nomName "Suthain";
+    rel:childOf <#Neill>.
+
+<#Neill>
+    a foaf:Person;
+    irishRel:genName "Neill";
+    irishRel:nomName "Niall";
+    rel:childOf <#Conduiligh>.
+
+<#Conduiligh>
+    a foaf:Person;
+    irishRel:genName "Con Duiligh";
+    irishRel:nomName "Cu Duiligh";
+    rdfs:comment "ab Lesa Mor sanabi";
+    foaf:title "ab"@sga, "abbot"@eng;
+    rel:childOf <#RaingRuaidh>.
+
+<#RaingRuaidh>
+    a foaf:Person;
+    irishRel:genName "Raing Ruaidh";
+    irishRel:nomName "Rang Ruadh";
+    rel:childOf <#Seandubgaill>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Seandubgaill>
+    a foaf:Person;
+    irishRel:genName "Seandubgaill";
+    irishRel:nomName "Seandubgall";
+    rdfs:comment "ar lss";
+    rel:childOf <#FherchairAbradraidh>.
+    #This name is abbreviated to "sean dubg" in the MS. Black takes "ar lss" to
+    #be a corruption of "Sgoinne" (of Scone). - EPT
+
+<#FherchairAbradruaidh>
+    a foaf:Person;
+    irishRel:genName "Fherchair Abradruaidh";
+    irishRel:nomName "Ferchar Abradruadh";
+    rel:childOf <#Feradhaigh>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradhach";
+    rel:childOf <#Fergusa>.
+
+<#Fergusa>
+    a foaf:Person;
+    irishRel:genName "Fergusa";
+    irishRel:nomName "Fergus";
+    rel:childOf <#Nechtain>.
+    #This name is illegible in the MS; Black seems to derive it mainly
+    #from readings in other MSS. - EPT
+
+<#Nechtain>
+    a foaf:Person;
+    irishRel:genName "Nechtain";
+    irishRel:nomName "Nechtan";
+    rel:childOf <#Colmain>.
+
+<#Colmain>
+    a foaf:Person;
+    irishRel:genName "Colmain";
+    irishRel:nomName "Colman";
+    rel:childOf <#Leatain>.
+
+<#Leatain>
+    a foaf:Person;
+    irishRel:genName "Leatain";
+    irishRel:nomName "Leatan";
+    rel:childOf <#Morgainn>.
+
+<#Morgainn>
+    a foaf:Person;
+    irishRel:genName "Morgainn";
+    irishRel:nomName "Morgann";
+    rel:childOf <#Domhnaill>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Morgainn>.
+
+<#Domhnaill>
+    a foaf:Person;
+    irishRel:genName "Domhnaill";
+    irishRel:nomName "Domhnall";
+    rel:childOf <#Cathmael>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Domnaill>.
+    #This name is illegible in the MS; Black seems to derive it mainly
+    #from readings in other MSS. - EPT
+
+<#Cathmael>
+    a foaf:Person;
+    irishRel:genName "Cathmael";
+    irishRel:nomName "Cathmael";
+    rel:childOf <#Ruaidri>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Cathmhaeil>.
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri";
+    rel:childOf _:missing-d8b35630;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Ruaidhri>.
+    #This name is illegible in the MS; Black seems to derive it mainly
+    #from readings in other MSS. - EPT
+
+_:missing-d8b35630
+    a foaf:Person;
+    rel:childOf <#Egac>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Aircheallaigh>.
+    #This name is partly illegible in the MS "[...]rullaigh"; Black takes it as
+    #a form of "Aircheallach". - EPT
+
+<#Egac>
+    a foaf:Person;
+    irishRel:genName "Egach";
+    irishRel:nomName "Eochu".
+    #This name is difficult to read in the MS. Black reads "cgac" and takes this as
+    #a corruption of "Echach" (genitive of Eochu). I am prepared to read the first
+    #"c" as "e". - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -176,6 +176,9 @@ _:missing-d8b35630
     irishRel:nomName "Eochu".
     #This name is difficult to read in the MS. Black reads "cgac" and takes this as
     #a corruption of "Echach" (genitive of Eochu). I am prepared to read the first
-    #"c" as "e". - EPT
+    #"c" as "e". Black suggests that this is Eochaidh Muinreamhair, on account of his
+    #appearance in the MacLean pedigree in other MSS. However, in these other MSS,
+    #Eochaidh Muinreamhair appears in a different context within the pedigree. This
+    #identification thus does not seem justified. - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -136,7 +136,7 @@
     a foaf:Person;
     irishRel:genName "Leatain";
     irishRel:nomName "Leatan";
-    rdfs:comment ".i. [...]"
+    rdfs:comment ".i. [...]";
     rel:childOf <#Morgainn>.
     #A comment has been added after this name, but, beyond the "ed ón" abbreviation,
     #it is now illegible. The name Buadan appears in the equivalent location in Kindred

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_24.trig
@@ -69,7 +69,7 @@
     rel:childOf <#ConDuiligh>.
 
 <#ConDuiligh>
-    a foaf:Person;
+    a IrishTitles:Abb;
     irishRel:genName "Con Duiligh";
     irishRel:nomName "Cu Duiligh";
     rdfs:comment "ab Lesa Mor sanab I";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig
@@ -33,7 +33,7 @@
 
 <#Cellaigh>
     a foaf:Person;
-    irishRel:genName "Cellaigh"
+    irishRel:genName "Cellaigh";
     irishRel:nomName "Cellach";
     rdfs:comment "in einigh";
     rel:childOf <#Turcaill>.

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig
@@ -1,0 +1,115 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Do Genelach Cloinni Guaire"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2025.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2025.html> .
+
+<#Ceallach>
+    a foaf:Person;
+    irishRel:nomName "Ceallach";
+    rel:childOf <#Poil>.
+
+<#Poil>
+    a foaf:Person;
+    irishRel:genName "Poil";
+    irishRel:nomName "Pol";
+    rel:childOf <#Cellaigh>.
+
+<#Cellaigh>
+    a foaf:Person;
+    irishRel:genName "Cellaigh"
+    irishRel:nomName "Cellach";
+    rdfs:comment "in einigh";
+    rel:childOf <#Turcaill>.
+
+<#Turcaill>
+    a foaf:Person;
+    irishRel:genName "Turcaill";
+    irishRel:nomName "Turcall";
+    rel:childOf <#Ceallaigh>.
+
+<#Ceallaigh>
+    a foaf:Person;
+    irishRel:genName "Ceallaigh";
+    irishRel:nomName "Ceallach";
+    rel:childOf <#Guaire>.
+
+<#Guaire>
+    a foaf:Person;
+    irishRel:genName "Guaire";
+    irishRel:nomName "Guaire";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#Murchaidh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Beathain>.
+
+<#Beathain>
+    a foaf:Person;
+    irishRel:genName "Beathain";
+    irishRel:nomName "Beathan";
+    rel:childOf <#Finnlaeich>.
+
+<#Finnlaeich>
+    a foaf:Person;
+    irishRel:genName "Finnlaeich";
+    irishRel:nomName "Finnlaech";
+    rel:childOf <#FerchairFada>.
+
+<#FerchairFada>
+    a foaf:Person;
+    irishRel:genName "Ferchair Fada";
+    irishRel:nomName "Ferchar Fada";
+    rel:childOf <#Feradaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+
+<#Feradaigh>
+    a foaf:Person;
+    irishRel:genName "Feradaigh";
+    irishRel:nomName "Feradach";
+    rel:childOf <#Ferghusa>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+<#Ferghusa>
+    a foaf:Person;
+    irishRel:genName "Ferghusa";
+    irishRel:nomName "Ferghus";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fergusa>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_26.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_26.trig
@@ -1,0 +1,97 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_26.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Do Genelach Mhic Fhinnguine .i. Mhic Colaim"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2026.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2026.html> .
+
+<#Niall>
+    a foaf:Person;
+    irishRel:nomName "Niall";
+    rel:childOf <#Gillebrigde>.
+
+<#Gillebrigde>
+    a foaf:Person;
+    irishRel:genName "Gille Brigde";
+    irishRel:nomName "Gille Brigde";
+    rel:childOf <#Eoghain>.
+
+<#Eoghain>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#GillaBrighde>.
+
+<#GillaBrighde>
+    a foaf:Person;
+    irishRel:genName "Gilla Brighde";
+    irishRel:nomName "Gilla Brighde";
+    rel:childOf <#Shaineaghain>.
+
+<#Shaineaghain>
+    a foaf:Person;
+    irishRel:genName "Shaineaghain";
+    irishRel:nomName "Seneoghan";
+    rel:childOf <#Fhinnlaeit>.
+
+<#Fhinnlaeit>
+    a foaf:Person;
+    irishRel:genName "Fhinnlaeit";
+    irishRel:nomName "Finnlaeth";
+    rel:childOf <#Finnguine>.
+
+<#Finnguine>
+    a foaf:Person;
+    irishRel:genName "Finnguine";
+    irishRel:nomName "Finnguine";
+    rdfs:comment "o filid Clann Finnguine";
+    irishRel:ancestorOfGroup <#ClannFinnguine>;
+    rel:childOf <#Cormaic>.
+
+<#ClannFinnguine>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Finnguine".
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig#Cormaic>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#Murchaidh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig#Airbertaigh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#FerchairOig>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig#Murchaidh>.
+
+<#FerchairOig>
+    a foaf:Person;
+    irishRel:genName "Ferchair Oig";
+    irishRel:nomName "Ferchar Og";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_25.trig#Ferchair>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -54,6 +54,7 @@
     irishRel:genName "Gilla Phadruig";
     irishRel:nomName "Gilla Padruig";
     rel:childOf <#GillaCrist>.
+    #This name is difficult to read in the MS. - EPT
 
 <#GillaCrist>
     a foaf:Person;
@@ -75,5 +76,130 @@
     irishRel:genName "Andradan";
     rdfs:comment "condregaidid Clanna Neill Naighiallaigh";
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#Anradan>.
+
+<#Caitrina>
+    a foaf:Person;
+    foaf:gender "female";
+    irishRel:nomName "Caitrina";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Laghmainn>.
+    #"mhic Laghmainn" could be a patronymic (i.e. Donnchadh's father is Laghmann),
+    #or it could be a surname (i.e. Donnchadh is a descendant of Laghmann). - EPT
+
+<#Laghmainn>
+    a foaf:Person;
+    irishRel:genName "Laghmainn";
+    irishRel:nomName "Lagmann".
+
+<#Cainnigh>
+    a foaf:Person;
+    irishRel:genName "Cainnigh";
+    irishRel:nomName "Cainneach";
+    rel:childOf <#Caitrina>;
+    owl:sameAs <#Caineac>.
+
+<#Padruig>
+    a foaf:Person;
+    irishRel:genName "Padruig";
+    irishRel:nomName "Padraig";
+    rel:childOf <#Caitrina>.
+
+<#GillaEaspuig>
+    a foaf:Person;
+    irishRel:genName "Gilla Easpuig";
+    irishRel:nomName "Gilla Easpuig";
+    rel:childOf <#Caitrina>.
+
+<#Agais>
+    a foaf:Person;
+    foaf:gender "female";
+    irishRel:nomName "Agais";
+    rel:childOf <#MhicDomnaill>.
+
+<#MhicDomnaill>
+    a foaf:Person;
+    irishRel:genName "Mhic Domnaill";
+    irishRel:nomName "Mac Domnaill".
+    #This is being taken as the head of Clann Domhnaill, at this period the Lord of the Isles,
+    #not "the son of Domnall"; it is not possible to say which Lord of the Isles is meant without
+    #reference to other sources. - EPT
+
+<#Eoin-8d8024f0>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Agais>;
+    owl:sameAs <#Eoin>.
+
+<#Ealasaid>
+    a foaf:Person;
+    foaf:gender "female";
+    irishRel:nomName "Ealasaid";
+    rel:childOf [
+      a foaf:Person;
+      foaf:title "mormair Comghuill"@sga, "mormaer of Cowall"@eng].
+
+<#LaclainnOig>
+    a foaf:Person;
+    irishRel:genName "Laclainn Oig";
+    irishRel:nomName "Lachlann Og";
+    rel:childOf <#Ealasaid>;
+    owl:sameAs <#Laclain>.
+
+<#GillaPadruig-118bbe70>
+    a foaf:Person;
+    irishRel:genName "Gilla Padruig";
+    irishRel:nomName "Gilla Padruig";
+    owl:sameAs <#GillaPadruig>;
+    rel:childOf [
+      a foaf:Person;
+      foaf:gender "female";
+      rel:childOf <#Enri>.
+    ].
+
+<#Enri>
+    a foaf:Person;
+    irishRel:nomName "Enri";
+    rel:childOf <#Ceinnedaigh>;
+    foaf:title "tigerna Cairrge"@sga, "lord of Carrick"@eng.
+
+<#Ceinnedaigh>
+    a foaf:Person;
+    irishRel:genName "Ceinnedaigh";
+    irishRel:nomName "Ceinnedach".
+
+<#Laclainn>
+    a foaf:Person;
+    irishRel:genName "Laclainn";
+    irishRel:nomName "Laclann";
+    rel:childOf <#Ruaidri>.
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri".
+
+<#GillaPadruig-3dae8b10>
+    a foaf:Person;
+    irishRel:genName "Gilla Padruig";
+    irishRel:nomName "Gilla Padruig";
+    owl:sameAs <#GillaPhadruig>;
+    rel:childOf [
+      a foaf:Person;
+      foaf:gender "female";
+      rel:childOf <#Laclainn>
+    ];
+    rel:parentOf <#LachlainnMoir>.
+
+<#LachlainnMoir>
+    a foaf:Person;
+    irishRel:genName "Lachlainn Moir";
+    irishRel:nomName "Lachlann Mor";
+    owl:sameAs <#LaclainnMoir>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -141,7 +141,7 @@
     foaf:gender "female";
     irishRel:nomName "Ealasaid";
     rel:childOf [
-      a foaf:Person;
+      a IrishTitles:Mormaer;
       foaf:title "mormair Comghuill"@sga, "mormaer of Cowall"@eng].
 
 <#LaclainnOig>
@@ -163,7 +163,7 @@
     ].
 
 <#Enri>
-    a foaf:Person;
+    a IrishTitles:Tigerna;
     irishRel:nomName "Enri";
     rel:childOf <#Ceinnedaigh>;
     foaf:title "tigerna Cairrge"@sga, "lord of Carrick"@eng.

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -146,7 +147,7 @@
     foaf:gender "female";
     irishRel:nomName "Ealasaid";
     rel:childOf [
-      a IrishTitles:Mormaer;
+      a IrishTitle:Mormaer;
       foaf:title "mormair Comghuill"@sga, "mormaer of Cowall"@eng].
 
 <#LaclainnOig>
@@ -168,7 +169,7 @@
     ].
 
 <#Enri>
-    a IrishTitles:Tigerna;
+    a IrishTitle:Tigerna;
     irishRel:nomName "Enri";
     rel:childOf <#Ceinnedaigh>;
     foaf:title "tigerna Cairrge"@sga, "lord of Carrick"@eng.

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -1,0 +1,79 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Do Genelach Mhic Lachlainn Oig"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2027.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2027.html> .
+
+<#Caineac>
+    a foaf:Person;
+    irishRel:nomName "Caineac";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Laclain>.
+
+<#Laclain>
+    a foaf:Person;
+    irishRel:genName "Laclain";
+    irishRel:nomName "Laclan";
+    rel:childOf <#GillaPadruig>.
+
+<#GillaPadruig>
+    a foaf:Person;
+    irishRel:genName "Gilla Padruig";
+    irishRel:nomName "Gilla Padruig";
+    rel:childOf <#LaclainnMoir>.
+
+<#LaclainnMoir>
+    a foaf:Person;
+    irishRel:genName "Laclainn Moir"
+    irishRel:nomName "Lachlann Mor";
+    rel:childOf <#GillaPhadruig>.
+
+<#GillaPhadruig>
+    a foaf:Person;
+    irishRel:genName "Gilla Phadruig";
+    irishRel:nomName "Gilla Padruig";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:nomName "Gilla Crist";
+    irishRel:genName "Gilla Crist";
+    rel:childOf <#DedaAlainn>.
+
+<#DedaAlainn>
+    a foaf:Person;
+    irishRel:genName "Deda Alainn";
+    irishRel:nomName "Ded Alainn";
+    rdfs:comment "renabartha Buirrce";
+    rel:childOf <#Anradan>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#AodaAlainn>.
+    #The reading "deda" is fairly clear in the MS, but Black suggests amending to "aeda". EPT
+
+<#Anradan>
+    a foaf:Person;
+    irishRel:genName "Andradan";
+    rdfs:comment "condregaidid Clanna Neill Naighiallaigh";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#Anradan>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -54,7 +54,9 @@
     irishRel:genName "Gilla Phadruig";
     irishRel:nomName "Gilla Padruig";
     rel:childOf <#GillaCrist>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaPhadruig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCrist>
     a foaf:Person;
@@ -69,7 +71,9 @@
     rdfs:comment "renabartha Buirrce";
     rel:childOf <#Anradan>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#AodaAlainn>.
-    #The reading "deda" is fairly clear in the MS, but Black suggests amending to "aeda". EPT
+    << <#DedaAlainn>
+          rdfs:comment "The reading 'deda' is fairly clear in the MS, but Black suggests amending to 'aeda'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Anradan>
     a foaf:Person;
@@ -88,8 +92,9 @@
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
     rel:childOf <#Laghmainn>.
-    #"mhic Laghmainn" could be a patronymic (i.e. Donnchadh's father is Laghmann),
-    #or it could be a surname (i.e. Donnchadh is a descendant of Laghmann). - EPT
+    << <#Donnchaidh>
+          rdfs:comment "'mhic Laghmainn' could be a patronymic (i.e. Donnchadh's father is Laghmann), or it could be a surname (i.e. Donnchadh is a descendant of Laghmann)." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Laghmainn>
     a foaf:Person;
@@ -125,9 +130,9 @@
     a foaf:Person;
     irishRel:genName "Mhic Domnaill";
     irishRel:nomName "Mac Domnaill".
-    #This is being taken as the head of Clann Domhnaill, at this period the Lord of the Isles,
-    #not "the son of Domnall"; it is not possible to say which Lord of the Isles is meant without
-    #reference to other sources. - EPT
+    << <#MhicDomnaill>
+          rdfs:comment "This is being taken as the head of Clann Domhnaill, at this period the Lord of the Isles, not 'the son of Domnall'; it is not possible to say which Lord of the Isles is meant without reference to other sources." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eoin-8d8024f0>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_27.trig
@@ -45,7 +45,7 @@
 
 <#LaclainnMoir>
     a foaf:Person;
-    irishRel:genName "Laclainn Moir"
+    irishRel:genName "Laclainn Moir";
     irishRel:nomName "Lachlann Mor";
     rel:childOf <#GillaPhadruig>.
 
@@ -159,7 +159,7 @@
     rel:childOf [
       a foaf:Person;
       foaf:gender "female";
-      rel:childOf <#Enri>.
+      rel:childOf <#Enri>
     ].
 
 <#Enri>

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
@@ -1,0 +1,212 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 28"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2028.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2028.html> .
+
+<#Alasdair>
+    a foaf:Person;
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Eoghain>.
+
+<#Eoghain>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#GillePedair>.
+
+<#GillePedair>
+    a foaf:Person;
+    irishRel:genName "Gille Pedair";
+    irishRel:nomName "Gille Pedair";
+    rel:childOf <#AlasdairMoir>.
+
+<#AlasdairMoir>
+    a foaf:Person;
+    irishRel:genName "Alasdair Moir";
+    irishRel:nomName "Alasdair Mor";
+    rel:childOf <#Eoghain-63373510>.
+
+<#Eoghain-63373510>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubghaill>.
+
+<#Dubghaill>
+    a foaf:Person;
+    irishRel:genName "Dubghaill";
+    irishRel:nomName "Dubghall";
+    rel:childOf <#Dubghaill>.
+
+<#Donnchadh>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubghuill>.
+    #Are we to understand this as <#Donnchaidh>, just mentioned? - EPT
+
+<#Dubghuill>
+    a foaf:Person;
+    irishRel:genName "Dubghuill";
+    irishRel:nomName "Dubghall";
+    rel:childOf <#Laclainn>.
+    #Are we to understand this as <#Dubghaill>, just mentioned? - EPT
+
+<#Laclainn>
+    a foaf:Person;
+    irishRel:genName "Laclainn";
+    irishRel:nomName "Laclann";
+    rel:childOf <#AlasdairMoir-07196680>.
+
+<#AlasdairMoir-07196680>
+    a foaf:Person;
+    irishRel:genName "Alasdair Moir";
+    irishRel:nomName "Alasdair Mor".
+    #Is this the same as <#AlasdairMoir>, above? - EPT
+
+<#Ragnall>
+    a foaf:Person;
+    irishRel:nomName "Ragnall";
+    rel:childOf <#Colaim>.
+
+<#Colaim>
+    a foaf:Person;
+    irishRel:genName "Colaim";
+    irishRel:nomName "Colam";
+    rel:childOf <#MaeilColaim>.
+
+<#MaeilColaim>
+    a foaf:Person;
+    irishRel:genName "Maeil Colaim";
+    irishRel:nomName "Mael Colam";
+    rel:childOf <#Dubghaill-820d3b00>.
+
+<#Dubghaill-820d3b00>
+    a foaf:Person;
+    irishRel:genName "Dubghaill";
+    irishRel:nomName "Dubghall";
+    rel:childOf <#GillaEspaig>.
+
+<#GillaEspaig>
+    a foaf:Person;
+    irishRel:genName "Gilla Espaig";
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Domhnaill>.
+
+<#Domhnaill>
+    a foaf:Person;
+    irishRel:genName "Domhnaill";
+    irishRel:nomName "Domhnall";
+    rel:childOf <#Donnchaidh-d7309460>.
+    #"domnaill mhic" has been inserted from the upper margin. - EPT
+
+<#Donnchaidh-d7309460>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh".
+
+<#Donnchaidh-4a67bfb0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf [
+      a foaf:Person;
+      foaf:gender "female";
+      rel:parentOf <#Donnchadh-107a9b20>
+    ].
+
+<#Donnchadh-107a9b20>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#GillaEspaig-25b0c050>.
+
+<#GillaEspaig-25b0c050>
+    a foaf:Person;
+    irishRel:genName "Gilla Espaig";
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Donnchaidh-ac80a9f0>.
+
+<#Donnchaidh-ac80a9f0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#GillaColaim>.
+
+<#GillaColaim>
+    a foaf:Person;
+    irishRel:genName "Gilla Colaim";
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#Imhair>.
+
+<#Imhair>
+    a foaf:Person;
+    irishRel:genName "Imhair";
+    irishRel:nomName "Imhar";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh-110934a0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh".
+    #There are several instances of "Donnchadh" in this section with which
+    #this could be identified. - EPT
+
+<#Niall>
+    a foaf:Person;
+    irishRel:nomName "Niall";
+    rel:childOf <#Cailin>.
+
+<#Cailin>
+    a foaf:Person;
+    irishRel:genName "Cailin";
+    irishRel:nomName "Cailin";
+    rel:childOf <#Donnchaidh-41de1f00>.
+
+<#Donnchaidh-41de1f00>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubghaill-67d3ae50>.
+
+<#Dubghaill-67d3ae50>
+    a foaf:Person;
+    irishRel:genName "Dubghaill";
+    irishRel:nomName "Dubghall";
+    foaf:title "persuin"@sga, "parson"@eng;
+    rel:childOf <#Dubhagan>.
+
+<#Dubhagan>
+    a foaf:Person;
+    irishRel:genName "Dubhagan";
+    rel:childOf <#Donnchaidh-a92d1cb0>.
+
+<#Donnchaidh-a92d1cb0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh".
+    #There are several instances of "Donnchadh" in this section with which
+    #this could be identified. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -198,7 +199,7 @@
     rel:childOf <#Dubghaill-67d3ae50>.
 
 <#Dubghaill-67d3ae50>
-    a IrishTitles:Persún;
+    a IrishTitle:Persún;
     irishRel:genName "Dubghaill";
     irishRel:nomName "Dubghall";
     foaf:title "persuin"@sga, "parson"@eng;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
@@ -123,7 +123,9 @@
     irishRel:genName "Domhnaill";
     irishRel:nomName "Domhnall";
     rel:childOf <#Donnchaidh-d7309460>.
-    #"domnaill mhic" has been inserted from the upper margin. - EPT
+    << <#Domhnaill>
+          rdfs:comment "'domnaill mhic' has been inserted from the upper margin." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Donnchaidh-d7309460>
     a foaf:Person;
@@ -174,8 +176,9 @@
     a foaf:Person;
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh".
-    #There are several instances of "Donnchadh" in this section with which
-    #this could be identified. - EPT
+    << <#Donnchaidh-110934a0>
+          rdfs:comment "There are several instances of 'Donnchadh' in this section with which this could be identified." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Niall>
     a foaf:Person;
@@ -211,9 +214,8 @@
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
     owl:sameAs <#Donnchaidh>.
-    #There are several instances of "Donnchadh" in this section with which
-    #this could be identified. The highest-level Donnchadh (son of Dubghall) has
-    #been selected on the basis that he seems least likely to need further
-    #specification within the text. - EPT
+    << <#Donnchaidh-a92d1cb0>
+          rdfs:comment "There are several instances of 'Donnchadh' in this section with which this could be identified. The highest-level Donnchadh (son of Dubghall) has been selected on the basis that he seems least likely to need further specification within the text." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_28.trig
@@ -41,38 +41,41 @@
     a foaf:Person;
     irishRel:genName "Alasdair Moir";
     irishRel:nomName "Alasdair Mor";
-    rel:childOf <#Eoghain-63373510>.
+    rel:childOf <#Eoghain-63373510>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4275634>.
 
 <#Eoghain-63373510>
     a foaf:Person;
     irishRel:genName "Eoghain";
     irishRel:nomName "Eoghan";
-    rel:childOf <#Donnchaidh>.
+    rel:childOf <#Donnchaidh>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3061707>.
 
 <#Donnchaidh>
     a foaf:Person;
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
-    rel:childOf <#Dubghaill>.
+    rel:childOf <#Dubghaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1216304>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Donnchaidh>.
 
 <#Dubghaill>
     a foaf:Person;
     irishRel:genName "Dubghaill";
     irishRel:nomName "Dubghall";
-    rel:childOf <#Dubghaill>.
+    rdfs:seeAlso <https://www.wikidata.org/wiki/Q3041014>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Dubghuill>.
 
 <#Donnchadh>
     a foaf:Person;
     irishRel:nomName "Donnchadh";
     rel:childOf <#Dubghuill>.
-    #Are we to understand this as <#Donnchaidh>, just mentioned? - EPT
 
 <#Dubghuill>
     a foaf:Person;
     irishRel:genName "Dubghuill";
     irishRel:nomName "Dubghall";
     rel:childOf <#Laclainn>.
-    #Are we to understand this as <#Dubghaill>, just mentioned? - EPT
 
 <#Laclainn>
     a foaf:Person;
@@ -83,8 +86,8 @@
 <#AlasdairMoir-07196680>
     a foaf:Person;
     irishRel:genName "Alasdair Moir";
-    irishRel:nomName "Alasdair Mor".
-    #Is this the same as <#AlasdairMoir>, above? - EPT
+    irishRel:nomName "Alasdair Mor";
+    owl:sameAs <#AlasdairMoir>.
 
 <#Ragnall>
     a foaf:Person;
@@ -125,7 +128,8 @@
 <#Donnchaidh-d7309460>
     a foaf:Person;
     irishRel:genName "Donnchaidh";
-    irishRel:nomName "Donnchadh".
+    irishRel:nomName "Donnchadh";
+    owl:sameAs <#Donnchaidh>.
 
 <#Donnchaidh-4a67bfb0>
     a foaf:Person;
@@ -191,7 +195,7 @@
     rel:childOf <#Dubghaill-67d3ae50>.
 
 <#Dubghaill-67d3ae50>
-    a foaf:Person;
+    a IrishTitles:Persún;
     irishRel:genName "Dubghaill";
     irishRel:nomName "Dubghall";
     foaf:title "persuin"@sga, "parson"@eng;
@@ -205,8 +209,11 @@
 <#Donnchaidh-a92d1cb0>
     a foaf:Person;
     irishRel:genName "Donnchaidh";
-    irishRel:nomName "Donnchadh".
+    irishRel:nomName "Donnchadh";
+    owl:sameAs <#Donnchaidh>.
     #There are several instances of "Donnchadh" in this section with which
-    #this could be identified. - EPT
+    #this could be identified. The highest-level Donnchadh (son of Dubghall) has
+    #been selected on the basis that he seems least likely to need further
+    #specification within the text. - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
@@ -60,7 +60,7 @@
     irishRel:genName "Duin Sleibe";
     irishRel:nomName "Don Sleibe";
     rel:childOf <#Buirrce>;
-    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#DuinnSleibe>.
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#DonnSleibe>.
 
 <#Buirrce>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Cloinni Somairle"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2029.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2029.html>, <https://www.1467manuscript.co.uk/Macsorley.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2029.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2029.html>, <https://www.1467manuscript.co.uk/Macsorley.pdf>.
 
 <#Domnall>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig
@@ -1,0 +1,70 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_29.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Somairle"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2029.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2029.html> .
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#GillaEspaig>.
+
+<#GillaEspaig>
+    a foaf:Person;
+    irishRel:genName "Gilla Espaig";
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Aengus>.
+
+<#Aengus>
+    a foaf:Person;
+    irishRel:genName "Aengus";
+    irishRel:nomName "Aengus";
+    rel:childOf <#Domnaill>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Shomairle>.
+
+<#Shomairle>
+    a foaf:Person;
+    irishRel:genName "Shomairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#DuinSleibe>.
+
+<#DuinSleibe>
+    a foaf:Person;
+    irishRel:genName "Duin Sleibe";
+    irishRel:nomName "Don Sleibe";
+    rel:childOf <#Buirrce>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#DuinnSleibe>.
+
+<#Buirrce>
+    a foaf:Person;
+    irishRel:genName "Buirrce";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig#AodaAlainn>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_3.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_3.trig
@@ -1,0 +1,54 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_3.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 3"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred%2003.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred%2003.html> .
+
+<#MacBethadh>
+    a foaf:Person;
+    irishRel:nomName "Mac Bethadh";
+    rel:childOf <#Finnlaeich>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q244403>.
+
+<#Finnlaeich>
+    a foaf:Person;
+    irishRel:genName "Finnlaeich";
+    irishRel:nomName "Finnlaech";
+    rel:childOf <#Ruaidhri>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q325259>.
+
+<#Ruaidhri>
+    a foaf:Person;
+    irishRel:genName "Ruaidhri";
+    irishRel:nomName "Ruaidhri";
+    rel:childOf <#Domnaill>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Morgainn>.
+
+<#Morgainn>
+    a foaf:Person;
+    irishRel:genName "Morgainn";
+    irishRel:nomName "Morgann";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Morgainn>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_30.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_30.trig
@@ -38,11 +38,14 @@
 _:missing-f07cff10
     a foaf:Person;
     foaf:gender "female";
-    rel:childOf [
-        a foaf:Person;
-        rel:childOf <#Ruaidri>
-        #Possibly "rel:descendantOf": is this a patronymic or a surname? - EPT
-    ].
+    rel:childOf _:missing-7d80e1b0.
+
+_:missing-7d80e1b0
+    a foaf:Person;
+    rel:childOf <#Ruaidri>.
+    << _:missing-7d80e1b0
+          rdfs:comment "Possibly rel:descendantOf: is this a patronymic or a surname?" >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ruaidri>
     a foaf:Person;
@@ -82,8 +85,9 @@ _:missing-799cc190
     irishRel:genName "Galtair";
     rdfs:comment ".i. righ Alban";
     rdfs:seeAlso <#https://www.wikidata.org/entity/Q958548>.
-    #There is no king of Scots on record called "Walter". This should possibly read
-    #".i. [sdibard] righ Alban", referring to Walter, 3rd High Steward of Scotland (ob. 1246). - EPT
+    << <#Galtair>
+          rdfs:comment "There is no king of Scots on record called 'Walter'. This should possibly read '.i. [sdibard] righ Alban', referring to Walter, 3rd High Steward of Scotland (ob. 1246)." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaEspaig>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_30.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_30.trig
@@ -1,0 +1,321 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_30.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Craebsgaeiledh Cloinni Domnaill annso .i. Clann Eoin a hIle"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2030.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2030.html> .
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf _:missing-f07cff10.
+
+<#Ragnall>
+    a foaf:Person;
+    irishRel:nomName "Ragnall";
+    rel:childOf _:missing-f07cff10.
+
+<#Cofraigh>
+    a foaf:Person;
+    irishRel:nomName "Cofraigh";
+    rel:childOf _:missing-f07cff10.
+
+_:missing-f07cff10
+    a foaf:Person;
+    foaf:gender "female";
+    rel:childOf [
+        a foaf:Person;
+        rel:childOf <#Ruaidri>
+        #Possibly "rel:descendantOf": is this a patronymic or a surname? - EPT
+    ].
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri".
+
+<#DomnallOg>
+    a foaf:Person;
+    irishRel:nomName "Domnall Og";
+    rel:childOf _:missing-799cc190.
+
+<#Eoin-923c0260>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf _:missing-799cc190.
+
+<#Aengus>
+    a foaf:Person;
+    irishRel:nomName "Aengus";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1967485>;
+    rel:childOf _:missing-799cc190.
+
+<#Alasdair>
+    a foaf:Person;
+    irishRel:nomName "Alasdair";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446743>;
+    rel:childOf _:missing-799cc190.
+
+_:missing-799cc190
+    a foaf:Person;
+    foaf:gender "female";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75268355>;
+    rel:childOf <#Galtair>.
+
+<#Galtair>
+    a foaf:Person;
+    irishRel:genName "Galtair";
+    rdfs:comment ".i. righ Alban";
+    rdfs:seeAlso <#https://www.wikidata.org/entity/Q958548>.
+    #There is no king of Scots on record called "Walter". This should possibly read
+    #".i. [sdibard] righ Alban", referring to Walter, 3rd High Steward of Scotland (ob. 1246). - EPT
+
+<#GillaEspaig>
+    a foaf:Person;
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Eoin-6b8d8de0>.
+
+<#Eoin-6b8d8de0>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Raghnaill>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    rel:childOf <#AlasdairOig>.
+
+<#AlasdairOig>
+    a foaf:Person;
+    irishRel:genName "Alasdair Oig";
+    irishRel:nomName "Alasdair Og";
+    rel:childOf <#AengusaMoir>;
+    owl:sameAs <#Alasdair>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q2833747>.
+
+<#AengusaMoir>
+    a foaf:Person;
+    irishRel:genName "Aengusa Moir";
+    irishRel:nomName "Aengus Mor";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1967485>.
+
+<#Gofraigh>
+    a foaf:Person;
+    irishRel:nomName "Gofraigh";
+    rel:childOf <#Aenghusa>.
+
+<#Aenghusa>
+    a foaf:Person;
+    irishRel:genName "Aenghusa";
+    irishRel:nomName "Aenghus";
+    rel:childOf <#AlasdairOig-12b77040>.
+
+<#AlasdairOig-12b77040>
+    a foaf:Person;
+    irishRel:genName "Alasdair Oig";
+    irishRel:nomName "Alasdair Og";
+    rel:childOf <#AengusaMoir-21d3b1b0>;
+    owl:sameAs <#AlasdairOig>.
+
+<#AengusaMoir-21d3b1b0>
+    a foaf:Person;
+    irishRel:genName "Aengusa Moir";
+    irishRel:nomName "Aengus Mor";
+    owl:sameAs <#AengusaMoir>.
+
+<#Somairle>
+    a foaf:Person;
+    irishRel:nomName "Somairle";
+    rel:childOf <#GillaBrigde>.
+
+<#GillaBrigde>
+    a foaf:Person;
+    irishRel:genName "Gilla Brigde";
+    irishRel:nomName "Gilla Brigde";
+    rel:childOf <#Gofraigh-1940c130>.
+
+<#Gofraigh-1940c130>
+    a foaf:Person;
+    irishRel:genName "Gofraigh";
+    irishRel:nomName "Gofraigh";
+    rel:childOf <#AlasdairMhoir>.
+
+<#AlasdairMhoir>
+    a foaf:Person;
+    irishRel:genName "Alasdair Mhoir";
+    irishRel:nomName "Alasdair Mor".
+
+<#Domnall-f5b07310>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#Alasdair-ef9d1f00>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q5290259>.
+
+<#Alasdair-ef9d1f00>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Domnaill>;
+    owl:sameAs <#AlasdairMhoir>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4708438>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Ragnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3036055>.
+
+<#Ragnaill>
+    a foaf:Person;
+    irishRel:genName "Ragnaill";
+    irishRel:nomName "Ragnall";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3417500>.
+
+<#Donnchadh>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    owl:sameAs <#Donnchaidh>;
+    rel:childOf <#Alasdair-87dd68b0>.
+
+<#Eoin-dc569f60>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    owl:sameAs <#Eoin>;
+    rel:childOf <#Alasdair-87dd68b0>.
+
+<#Alasdair-87dd68b0>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Domhnaill>;
+    owl:sameAs <#Alasdair-ef9d1f00>.
+
+<#Domhnaill>
+    a foaf:Person;
+    irishRel:genName "Domhnaill";
+    irishRel:nomName "Domhnall";
+    owl:sameAs <#Domnaill>;
+    rel:childOf <#Raghnaill-bbd4efd0>.
+
+<#Raghnaill-bbd4efd0>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    owl:sameAs <#Ragnaill>.
+
+<#Eoin-7514a490>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Donnchaidh>.
+
+<#Gillespaig>
+    a foaf:Person;
+    irishRel:nomName "Gillespaig";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Alasdair-b4e995d0>.
+
+<#Alasdair-b4e995d0>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Domnaill-c29445e0>;
+    owl:sameAs <#Alasdair-ef9d1f00>.
+
+<#Domnaill-c29445e0>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Ragnaill-e1bddf80>;
+    owl:sameAs <#Domnaill>.
+
+<#Ragnaill-e1bddf80>
+    a foaf:Person;
+    irishRel:genName "Ragnaill";
+    irishRel:nomName "Ragnall";
+    owl:sameAs <#Ragnaill>.
+
+<#Toirrdealbhach>
+    a foaf:Person;
+    irishRel:nomName "Toirrdealbhach";
+    rel:childOf <#Eachainn>.
+
+<#Loclann>
+    a foaf:Person;
+    irishRel:nomName "Loclann";
+    rel:childOf <#Eachainn>.
+
+<#Eachainn>
+    a foaf:Person;
+    irishRel:genName "Eachainn";
+    irishRel:nomName "Eachann";
+    rel:childOf <#Alasdair-2d86f730>.
+
+<#Alasdair-2d86f730>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Domnaill-400a3160>;
+    owl:sameAs <#Alasdair-ef9d1f00>.
+
+<#Domnaill-400a3160>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Ragnaill-58a8d5f0>;
+    owl:sameAs <#Domnaill>.
+
+<#Ragnaill-58a8d5f0>
+    a foaf:Person;
+    irishRel:genName "Ragnaill";
+    irishRel:nomName "Ragnall";
+    owl:sameAs <#Ragnaill>.
+
+<#Domnall-8567c2e0>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#Aengusa>.
+
+<#Aengusa>
+    a foaf:Person;
+    irishRel:genName "Aengusa";
+    irishRel:nomName "Aengus";
+    rel:childOf <#EoinSprangaigh>.
+
+<#EoinSprangaigh>
+    a foaf:Person;
+    irishRel:genName "Eoin Spangaigh";
+    irishRel:nomName "Eoin Sprangach";
+    rel:child <#AengusaMoir-6013d550>;
+    owl:sameAs <#Eoin-923c0260>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q5980617>.
+
+<#AengusaMoir-6013d550>
+    a foaf:Person;
+    irishRel:genName "Aengusa Moir";
+    irishRel:nomName "Aengus Mor";
+    owl:sameAs <#AengusaMoir>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
@@ -112,7 +112,7 @@
     irishRel:genName "Alasdair";
     irishRel:nomName "Alasdair";
     rel:childOf <#Eoghain>;
-    rdfs:seeAlso <https://www.wikidata.org/entity/Q4275634>
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4275634>.
 
 <#Eoghain>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
@@ -70,7 +70,9 @@
     rel:childOf <#Somhairle>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q3417500>;
     rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/6562>.
-    #As Black points out, this is incorrect: Dubghall and Raghnall are brothers. - EPT
+    << <#Raghnaill>
+          rdfs:comment "As Black points out, this is incorrect: Dubghall and Raghnall are brothers." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Somhairle>
     a foaf:Person;
@@ -167,7 +169,9 @@
     irishRel:nomName "Eoin";
     rel:childOf <#Donnchaidh-7e596ca0>;
     owl:sameAs <#Eoghain>, <#EoinBogaigh>.
-    #The "mic" is missing between "Eoin" and "Donnchaidh". - EPT
+    << <#Eoin-5cf413d0>
+          rdfs:comment "The 'mic' is missing between 'Eoin' and 'Donnchaidh'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Donnchaidh-7e596ca0>
     a foaf:Person;
@@ -205,8 +209,9 @@
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
     owl:sameAs <#Donnchaidh>.
-    #A "mhic" follows "Donnchaidh" but, as Black points out, the text makes more
-    #sense if it is ignored. - EPT
+    << <#Donnchaidh-3e915730>
+          rdfs:comment "A 'mhic' follows 'Donnchaidh' but, as Black points out, the text makes more sense if it is ignored." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Mailcolaim>
     a foaf:Person;
@@ -239,7 +244,9 @@
     irishRel:genName "Dubgaill";
     irishRel:nomName "Dubgall";
     owl:sameAs <#Dubghuill>.
-    #Black suggests that Dubghall has been added here by mistake. - EPT
+    << <#Dubgaill-95b8a170>
+          rdfs:comment "Black suggests that Dubghall has been added here by mistake." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ferchar>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
@@ -53,25 +53,31 @@
     a foaf:Person;
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
-    rel:childOf <#Dubghuill>.
+    rel:childOf <#Dubghuill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1216304>.
 
 <#Dubghuill>
     a foaf:Person;
     irishRel:genName "Dubghuill";
     irishRel:nomName "Dubghall";
-    rel:childOf <#Raghnaill>.
+    rel:childOf <#Raghnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3041014>.
 
 <#Raghnaill>
     a foaf:Person;
     irishRel:genName "Raghnaill";
     irishRel:nomName "Raghnall";
-    rel:childOf <#Somhairle>.
+    rel:childOf <#Somhairle>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3417500>;
+    rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/6562>.
     #As Black points out, this is incorrect: Dubghall and Raghnall are brothers. - EPT
 
 <#Somhairle>
     a foaf:Person;
     irishRel:genName "Somhairle";
-    irishRel:nomName "Somhairle".
+    irishRel:nomName "Somhairle";
+    rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/337>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1781786>.
 
 <#Eoin-67293710>
     a foaf:Person;
@@ -91,25 +97,29 @@
 <#AlasdairOg>
     a foaf:Person;
     irishRel:nomName "Alasdair Og";
-    rel:childOf <#Eoin-83512970>.
+    rel:childOf <#Eoin-83512970>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q76072177>.
 
 <#Eoin-83512970>
     a foaf:Person;
     irishRel:genName "Eoin";
     irishRel:nomName "Eoin";
-    rel:childOf <#Alasdair-2c1b7560>.
+    rel:childOf <#Alasdair-2c1b7560>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4275635>.
 
 <#Alasdair-2c1b7560>
     a foaf:Person;
     irishRel:genName "Alasdair";
     irishRel:nomName "Alasdair";
-    rel:childOf <#Eoghain>.
+    rel:childOf <#Eoghain>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4275634>
 
 <#Eoghain>
     a foaf:Person;
     irishRel:genName "Eoghain";
     irishRel:nomName "Eoghan";
-    rel:childOf <#Donnchaidh-5aa696d0>.
+    rel:childOf <#Donnchaidh-5aa696d0>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3061707>.
 
 <#Donnchaidh-5aa696d0>
     a foaf:Person;
@@ -299,7 +309,7 @@
     irishRel:genName "Eoin";
     irishRel:nomName "Eoin";
     rel:childOf <#Donnchaidh-a5da9da0>;
-    owl:sameAs <#Dubghuill>.
+    owl:sameAs <#Eoin-5cf413d0>.
 
 <#Donnchaidh-a5da9da0>
     a foaf:Person;
@@ -312,6 +322,6 @@
     a foaf:Person;
     irishRel:genName "Dubgaill";
     irishRel:nomName "Dubgall";
-    owl:sameAs <#Eoghain>.
+    owl:sameAs <#Dubghuill>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig
@@ -1,0 +1,317 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Somairle"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2031.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2031.html> .
+
+<#Ailein>
+    a foaf:Person;
+    irishRel:nomName "Ailein";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Ailin>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailein";
+    rel:childOf <#Eoin-dd4eb010>.
+
+<#Eoin-dd4eb010>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Alasdair>.
+
+<#Alasdair>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubghuill>.
+
+<#Dubghuill>
+    a foaf:Person;
+    irishRel:genName "Dubghuill";
+    irishRel:nomName "Dubghall";
+    rel:childOf <#Raghnaill>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    rel:childOf <#Somhairle>.
+    #As Black points out, this is incorrect: Dubghall and Raghnall are brothers. - EPT
+
+<#Somhairle>
+    a foaf:Person;
+    irishRel:genName "Somhairle";
+    irishRel:nomName "Somhairle".
+
+<#Eoin-67293710>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Eoin-83512970>.
+
+<#Somairle>
+    a foaf:Person;
+    irishRel:nomName "Somairle";
+    rel:childOf <#Eoin-83512970>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:nomName "Ailin";
+    rel:childOf <#Eoin-83512970>.
+
+<#AlasdairOg>
+    a foaf:Person;
+    irishRel:nomName "Alasdair Og";
+    rel:childOf <#Eoin-83512970>.
+
+<#Eoin-83512970>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Alasdair-2c1b7560>.
+
+<#Alasdair-2c1b7560>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Eoghain>.
+
+<#Eoghain>
+    a foaf:Person;
+    irishRel:genName "Eoghain";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Donnchaidh-5aa696d0>.
+
+<#Donnchaidh-5aa696d0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubghaill>;
+    owl:sameAs <#Donnchaidh>.
+
+<#Dubghaill>
+    a foaf:Person;
+    irishRel:genName "Dubghaill";
+    irishRel:nomName "Dubghall";
+    owl:sameAs <#Dubghuill>.
+
+<#EoinBogaigh>
+    a foaf:Person;
+    irishRel:genName "Eoin Bogaigh";
+    irishRel:nomName "Eoin Bogach";
+    irishRel:ancestorOfGroup <#ClannEoinBogaigh>.
+
+<#ClannEoinBogaigh>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Eoin Bogaigh".
+
+<#Eoghan>
+    a foaf:Person;
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Lochlainn>.
+
+<#Lochlainn>
+    a foaf:Person;
+    irishRel:genName "Lochlainn";
+    irishRel:nomName "Lochlann";
+    rel:childOf <#Shomairle>.
+
+<#Shomairle>
+    a foaf:Person;
+    irishRel:genName "Shomairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#Eoin-5cf413d0>.
+
+<#Eoin-5cf413d0>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Donnchaidh-7e596ca0>;
+    owl:sameAs <#Eoghain>, <#EoinBogaigh>.
+    #The "mic" is missing between "Eoin" and "Donnchaidh". - EPT
+
+<#Donnchaidh-7e596ca0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubgaill>;
+    owl:sameAs <#Donnchaidh>.
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    owl:sameAs <#Dubghuill>.
+
+<#Donnchadh>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Alasdair-08ca6740>.
+
+<#Alasdair-08ca6740>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Eoin-25c5af30>.
+
+<#Eoin-25c5af30>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Donnchaidh-3e915730>;
+    owl:sameAs <#Eoghain>.
+
+<#Donnchaidh-3e915730>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    owl:sameAs <#Donnchaidh>.
+    #A "mhic" follows "Donnchaidh" but, as Black points out, the text makes more
+    #sense if it is ignored. - EPT
+
+<#Mailcolaim>
+    a foaf:Person;
+    irishRel:genName "Mail Colaim";
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#Loclainn>.
+
+<#Loclainn>
+    a foaf:Person;
+    irishRel:genName "Loclainn";
+    irishRel:nomName "Loclann";
+    rel:childOf <#Eoin-abdd13b0>.
+
+<#Eoin-abdd13b0>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Donnchaidh-c3b5a920>;
+    owl:sameAs <#Eoghain>.
+
+<#Donnchaidh-c3b5a920>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubgaill-95b8a170>;
+    owl:sameAs <#Donnchaidh>.
+
+<#Dubgaill-95b8a170>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    owl:sameAs <#Dubghuill>.
+    #Black suggests that Dubghall has been added here by mistake. - EPT
+
+<#Ferchar>
+    a foaf:Person;
+    irishRel:nomName "Ferchar";
+    rel:childOf <#GillaColaim>.
+
+<#Loclann>
+    a foaf:Person;
+    irishRel:nomName "Loclann";
+    rel:childOf <#GillaColaim>.
+
+<#Imar>
+    a foaf:Person;
+    irishRel:nomName "Imar";
+    rel:childOf <#GillaColaim>.
+
+<#GillaColaim>
+    a foaf:Person;
+    irishRel:genName "Gilla Colaim";
+    irishRel:nomName "Gilla Colaim";
+    rel:childOf <#Imair>.
+
+<#Imair>
+    a foaf:Person;
+    irishRel:genName "Imair";
+    irishRel:nomName "Imar";
+    rel:childOf <#Dubghaill-f20e0550>.
+
+<#Dubghaill-f20e0550>
+    a foaf:Person;
+    irishRel:genName "Dubghaill";
+    irishRel:nomName "Dubghall";
+    rel:childOf <#Loclainn-0c18e410>.
+
+<#Loclainn-0c18e410>
+    a foaf:Person;
+    irishRel:genName "Loclainn";
+    irishRel:nomName "Loclann";
+    rel:childOf <#Donnchaidh-23961310>.
+
+<#Donnchaidh-23961310>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubgaill-3d1860e0>.
+
+<#Dubgaill-3d1860e0>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall".
+
+<#Alasdair-58677f70>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Eoin-6b3d6d80>.
+
+<#Somairle-58677f70>
+    a foaf:Person;
+    irishRel:genName "Somairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#Eoin-6b3d6d80>;
+    owl:sameAs <#Shomairle>.
+
+<#Eoin-6b3d6d80>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Donnchaidh-a5da9da0>;
+    owl:sameAs <#Dubghuill>.
+
+<#Donnchaidh-a5da9da0>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubgaill-be9a10a0>;
+    owl:sameAs <#Donnchaidh>.
+
+<#Dubgaill-be9a10a0>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    owl:sameAs <#Eoghain>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_32.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_32.trig
@@ -83,9 +83,9 @@
     a foaf:Person;
     irishRel:genName "Ragnaill";
     irishRel:nomName "Ragnall".
-    #I am currently unable to identify this individual: Raghnall son of Somhairle
-    #(<#Raghnaill>) would be the most natural identification, in terms of reading
-    #these pedigrees but he does not have a son called Ailen in other sources. - EPT
+    << <#Ragnaill>
+          rdfs:comment "I am currently unable to identify this individual: Raghnall son of Somhairle (<#Raghnaill>) would be the most natural identification, in terms of reading these pedigrees but he does not have a son called Ailen in other sources." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Fearchar>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_32.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_32.trig
@@ -1,0 +1,127 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_32.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kinded 32"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2032.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2032.html> .
+
+<#RaghnallFinn>
+    a foaf:Person;
+    irishRel:nomName "Raghnall Finn";
+    rel:childOf <#Ruaidri>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q21751050>.
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri";
+    rel:childOf <#Ailin>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q23884905>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailen";
+    rel:childOf <#Ruaidri-0c602f50>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q4697013>.
+
+<#Ruaidri-0c602f50>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri";
+    rel:childOf <#Raghnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q976433>;
+    rdfs:seeAlso <https://www.poms.ac.uk/rdf/entity/Person/6566>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    rel:childOf <#Shomairle>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Raghnaill>.
+
+<#Shomairle>
+    a foaf:Person;
+    irishRel:genName "Shomairle";
+    irishRel:nomName "Somairle";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Somhairle>.
+
+<#RagnallFinn>
+    a foaf:Person;
+    irishRel:nomName "Ragnall Finn";
+    rdfs:comment "ele";
+    rel:childOf <#Loclainn>.
+
+<#Loclainn>
+    a foaf:Person;
+    irishRel:genName "Loclainn";
+    irishRel:nomName "Lochlann";
+    rel:childOf <#Ailin>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailen";
+    rel:childOf <#Ragnaill>.
+
+<#Ragnaill>
+    a foaf:Person;
+    irishRel:genName "Ragnaill";
+    irishRel:nomName "Ragnall".
+    #I am currently unable to identify this individual: Raghnall son of Somhairle
+    #(<#Raghnaill>) would be the most natural identification, in terms of reading
+    #these pedigrees but he does not have a son called Ailen in other sources. - EPT
+
+<#Fearchar>
+    a foaf:Person;
+    irishRel:nomName "Fearchar";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchadh>
+    a foaf:Person;
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Dubgaill>.
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#Ruaidri-85a6de20>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3041001>.
+
+<#Ruaidri-85a6de20>
+    a foaf:Person;
+    irishRel:genName "Ruaidri";
+    irishRel:nomName "Ruaidri";
+    rel:childOf <#Ragnaill-a23162e0>;
+    owl:sameAs <#Ruaidri-0c602f50>.
+
+<#Ragnaill-a23162e0>
+    a foaf:Person;
+    irishRel:genName "Ragnaill";
+    irishRel:nomName "Ragnall";
+    owl:sameAs <#Raghnaill>;
+    rdfs:comment "condrecaid Clann Ruaidri 7 Clann Domnaill 7 Clann Dubghaill".
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig
@@ -24,7 +24,7 @@
     a foaf:Person;
     irishRel:nomName "Eoin Dub";
     rel:childOf <#Alasdair>;
-    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446747>
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446747>.
 
 <#Alasdair>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig
@@ -1,0 +1,70 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Clann Domhnaill beos"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2033.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2033.html> .
+
+<#EoinDub>
+    a foaf:Person;
+    irishRel:nomName "Eoin Dub";
+    rel:childOf <#Alasdair>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446747>
+
+<#Alasdair>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Aenghusa>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446745>.
+
+<#AenghusaMoir>
+    a foaf:Person;
+    irishRel:genName "AenghusaMoir";
+    irishRel:nomName "Aenghus Mor";
+    rel:childOf <#Domnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1967485>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Raghnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3036055>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    rel:childOf <#Shomairle>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Raghnaill>.
+
+<#Shomairle>
+    a foaf:Person;
+    irishRel:genName "Shomairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#GilleBride>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Somhairle>.
+
+<#GilleBride>
+    a foaf:Person;
+    irishRel:genName "Gille Bride";
+    irishRel:nomName "Gille Bride";
+    rel:childOf <#GilleBride>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
@@ -1,0 +1,213 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 34"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2034.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2034.html> .
+
+<#EoinAhIle>
+    a foaf:Person;
+    irishRel:nomName "Eoin a hIle";
+    irishRel:ancestorOfGroup <#ClannDomnaill>, <#ClannRaghnaill>, <#ClannGhofraigh>.
+
+<#ClannDomnaill>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Domnaill".
+
+<#ClannRaghnaill>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Raghnaill".
+
+<#ClannGhofraigh>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Ghofraigh".
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:nomName "Ailin".
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rdfs:comment "do bi dall fadeoigh".
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:nomName "Domnall".
+
+<#AengusRiabach>
+    a foaf:Person;
+    irishRel:nomName "Aengus Riabhach".
+
+<#Dubghall>
+    a foaf:Person;
+    irishRel:nomName "Dubghall".
+
+<#Ruaidri>
+    a foaf:Person;
+    irishRel:nomName "Ruaidri"
+    rel:childOf <#Ailin>.
+
+<#Uisdiun>
+    a foaf:Person;
+    irishRel:nomName "Uisdiun";
+    rel:childOf <#Ailin>.
+
+<#Eoin-4ced7b60>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Ailin>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Raghnaill>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig#Domnaill>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Raghnaill>.
+
+<#Eoin-072fd310>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Domnaill>, <#Lainglib>.
+
+<#Lainglib>
+    a foaf:Person;
+    foaf:gender "female";
+    irishRel:nomName "Lainglib";
+    rel:childOf <#Cimair>.
+
+<#Cimair>
+    a foaf:Person;
+    irishRel:genName "Cimair";
+    irishRel:nomName "Mac Cimair".
+
+<#AlasdairNaCaille>
+    a foaf:Person;
+    irishRel:nomName "Alasdair na Caille";
+    rel:childOf <#Domnaill>.
+
+<#AengusOghar>
+    a foaf:Person;
+    irishRel:nomName "Aenghus Oghar";
+    rel:childOf <#Domnaill>.
+
+<#EoinDall>
+    a foaf:Person;
+    irishRel:nomName "Eoin Dall";
+    owl:sameAs <#Eoin>, <#Eoin-072fd310>;
+    rel:childOf [
+      a foaf:Person;
+      foaf:gender "female";
+      rel:childOf <#MhicCimi>;
+      owl:sameAs <#Lainglib>
+    ].
+
+<#MhicCimi>
+    a foaf:Person;
+    irishRel:genName "Mhic Cimi";
+    owl:sameAs <#Cimair>.
+
+<#Eoin-04ec2f30>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#EoinDall>.
+
+<#AengusRiabhach>
+    a foaf:Person;
+    irishRel:nomName "Aengus Riabhach";
+    owl:sameAs <#AengusRiabach>;
+    rdfs:comment "aen mhac maith aige";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q76060800>.
+    #Black states that this individual died in 1440, but the Wikidata entry has
+    #him dying in 1400. Is this the same person? - EPT
+
+<#AenghusOg>
+    a foaf:Person;
+    irishRel:nomName "Aenghus Og";
+    rdfs:comment "agarobusa fen am aelanach og";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q76060801>.
+    #This Wikidata identification is based on the assumption that that for
+    #<#AengusRiabhach> is accurate. - EPT
+
+_:missing-6f82ddd0
+    a foaf:person;
+    irishRel:fosterChildOf <#AenghusOg>.
+    #Here, either Dubghall Albanach Mac Mic Chathail or a previous compiler refers
+    #is talking about themselves in the first person. - EPT
+
+<#Dubgaill>
+    a foaf:Person;
+    irishRel:genName "Dubgaill";
+    irishRel:nomName "Dubgall";
+    rel:childOf <#Raghnaill-be6bddb0>;
+    owl:sameAs <#Dubghall>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Dubghuill>.
+
+<#Raghnaill-be6bddb0>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    owl:sameAs <#Raghnaill>.
+
+_:missing-dbc990f0
+    a foaf:Person;
+    rel:childOf <#Dubgaill>.
+    #The MS is illegible at this point. - EPT
+
+<#AengusRuadh>
+    a foaf:Person;
+    irishRel:nomName "Aengus Ruadh";
+    rel:childOf <#Dubgaill>.
+
+<#Gofraigh>
+    a foaf:Person;
+    irishRel:genName "Gofraigh";
+    irishRel:nomName "Gofraigh";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446762>.
+
+<#Aengus>
+    a foaf:Person;
+    irishRel:nomName "Aengus";
+    rel:childOf <#Gofraigh>;
+    irishRel:numChild 0;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75388258>.
+
+<#Eoin-92925240>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Gofraigh>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q75446759>.
+
+<#Somairle>
+    a foaf:Person;
+    irishRel:nomName "Somairle";
+    rel:childOf <#Gofraigh>.
+
+<#Ragnall>
+    a foaf:Person;
+    irishRel:nomName "Ragnall";
+    rel:childOf <#Gofraigh>;
+    owl:sameAs <#Raghnaill>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
@@ -140,22 +140,25 @@
     rel:parentOf <#AenghusOg>;
     rdfs:comment "aen mhac maith aige";
     rdfs:seeAlso <https://www.wikidata.org/entity/Q76060800>.
-    #Black states that this individual died in 1440, but the Wikidata entry has
-    #him dying in 1400. Is this the same person? - EPT
+    << <#AengusRiabhach>
+          rdfs:comment "Black states that this individual died in 1440, but the Wikidata entry has him dying in 1400. Is this the same person?" >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#AenghusOg>
     a foaf:Person;
     irishRel:nomName "Aenghus Og";
     rdfs:comment "agarobusa fen am aelanach og";
     rdfs:seeAlso <https://www.wikidata.org/entity/Q76060801>.
-    #This Wikidata identification is based on the assumption that that for
-    #<#AengusRiabhach> is accurate. - EPT
+    << <#AenghusOg>
+          rdfs:comment "This Wikidata identification is based on the assumption that that for <#AengusRiabhach> is accurate." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 _:missing-6f82ddd0
     a foaf:person;
     irishRel:fosterChildOf <#AenghusOg>.
-    #Here, either Dubghall Albanach Mac Mic Chathail or a previous compiler refers
-    #is talking about themselves in the first person. - EPT
+    << _:missing-6f82ddd0
+          rdfs:comment "Here, either Dubghall Albanach Mac Mic Chathail or a previous compiler refers is talking about themselves in the first person." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Dubgaill>
     a foaf:Person;
@@ -174,7 +177,9 @@ _:missing-6f82ddd0
 _:missing-dbc990f0
     a foaf:Person;
     rel:childOf <#Dubgaill>.
-    #The MS is illegible at this point. - EPT
+    << _:missing-dbc990f0
+          rdfs:comment "The MS is illegible at this point." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#AengusRuadh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
@@ -137,6 +137,7 @@
     a foaf:Person;
     irishRel:nomName "Aengus Riabhach";
     owl:sameAs <#AengusRiabach>;
+    rel:parentOf <#AenghusOg>;
     rdfs:comment "aen mhac maith aige";
     rdfs:seeAlso <https://www.wikidata.org/entity/Q76060800>.
     #Black states that this individual died in 1440, but the Wikidata entry has

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_34.trig
@@ -60,7 +60,7 @@
 
 <#Ruaidri>
     a foaf:Person;
-    irishRel:nomName "Ruaidri"
+    irishRel:nomName "Ruaidri";
     rel:childOf <#Ailin>.
 
 <#Uisdiun>

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
@@ -16,10 +16,754 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Mhic Domnaill annso"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>.
 
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#Alasdair>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3172627>
 
+<#Alasdair>
+    a foaf:Person;
+    irishRel:genName "Alasdair";
+    irishRel:nomName "Alasdair";
+    rel:childOf <#Domnall>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q2833745>.
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:genName "Domnall";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Eoin-b674fe50>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3036052>.
+    #Sic. The nominative form appears for the genitive in the MS. - EPT
+
+<#Eoin-b674fe50>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#AengusaOig>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3024016>.
+
+<#AengusaOig>
+    a foaf:Person;
+    irishRel:genName "Aengusa Oig";
+    irishRel:nomName "Aengus Og";
+    rel:childOf <#AengusaMoir>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q593666>.
+
+<#AengusaMoir>
+    a foaf:Person;
+    irishRel:genName "Aengusa Moir";
+    irishRel:nomName "Aengus Mor";
+    rel:childOf <#Domnaill>;
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q1967485>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rel:childOf <#Raghnaill>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig#Domnaill>.
+
+<#Raghnaill>
+    a foaf:Person;
+    irishRel:genName "Raghnaill";
+    irishRel:nomName "Raghnall";
+    rel:childOf <#Somairle>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Raghnaill>.
+
+<#Somairle>
+    a foaf:Person;
+    irishRel:genName "Somairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#GilleBrigde>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_31.trig#Somhairle>.
+
+<#GilleBrigde>
+    a foaf:Person;
+    irishRel:genName "Somairle";
+    irishRel:nomName "Somairle";
+    rel:childOf <#GillaEaghanain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_33.trig#GilleBride>.
+
+<#GillaEaghanain>
+    a foaf:Person;
+    irishRel:genName "Gilla Eaghanain";
+    irishRel:nomName "Gilla Eaghanain";
+    rel:childOf <#Solaim>.
+
+<#Solaim>
+    a foaf:Person;
+    irishRel:genName "Solaim";
+    irishRel:nomName "Solam";
+    rel:childOf <#Mergadh>.
+
+<#Mergadh>
+    a foaf:Person;
+    irishRel:genName "Mergadh";
+    rel:childOf <#Suibne>.
+
+<#Suibne>
+    a foaf:Person;
+    irishRel:genName "Suibne";
+    irishRel:nomName "Suibne";
+    rel:childOf <#Niallgusa>.
+
+<#Niallgusa>
+    a foaf:Person;
+    irishRel:genName "Niallgusa";
+    irishRel:nomName "Niallgus";
+    rel:childOf <#Maine>.
+
+<#Maine>
+    a foaf:Person;
+    irishRel:genName "Maine";
+    irishRel:nomName "Maine";
+    rel:childOf <#Gofraigh>.
+
+<#Gofraigh>
+    a foaf:Person;
+    irishRel:genName "Gofraigh";
+    irishRel:nomName "Gofraigh";
+    rel:childOf <#Fergusa>.
+
+<#Fergusa>
+    a foaf:Person;
+    irishRel:genName "Fergusa";
+    irishRel:nomName "Fergus";
+    rel:childOf <#Eirc>.
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#Carthainn>.
+
+<#Carthainn>
+    a foaf:Person;
+    irishRel:genName "Carthainn";
+    irishRel:nomName "Carthann";
+    rel:childOf <#EathachFigli>.
+
+<#EathachFigli>
+    a foaf:Person;
+    irishRel:genName "Eathach Figli";
+    rel:childOf <#CollaDuais>.
+
+<#CollaDuais>
+    a foaf:Person;
+    irishRel:genName "Colla Duais";
+    irishRel:nomName "Colla Duais";
+    rel:childOf <#EathachDoimlen>;
+    owl:sameAs <http://example.com/LL/h_airgialla.trig#CollaOss>.
+
+<#EathachDoimlen>
+    a foaf:Person;
+    irishRel:genName "Eathach Doimlen";
+    irishRel:nomName "Eochaid Doimlen";
+    rel:childOf <#CairpriLifechair>;
+    owl:sameAs <http://example.com/LL/h_airgialla.trig#EochoDomlén>.
+
+<#CairpriLifechair>
+    a foaf:Person;
+    irishRel:genName "Cairpri Lifechair";
+    irishRel:nomName "Cairpre Lifechair";
+    rel:childOf <#CormaicUlfata>;
+    owl:sameAs <http://example.com/LL/h_airgialla.trig#CorpriLiphechair>.
+
+<#CormaicUlfata>
+    a foaf:Person;
+    irishRel:genName "Cormaic Ulfata";
+    irishRel:nomName "Cormac Ulfata";
+    rdfs:comment ".i. ulcha fa";
+    rel:childOf <#AirtAinfir>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CormaicUlfhota>.
+
+<#AirtAinfir>
+    a foaf:Person;
+    irishRel:genName "Airt Ainfir";
+    irishRel:nomName "Art Aenfer";
+    rel:childOf <#CuinnCedcathaigh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#ArtOenfhir>.
+
+<#CuinnCedcathaigh>
+    a foaf:Person;
+    irishRel:genName "Cuinn Cedcathaigh";
+    irishRel:nomName "Conn Cetcathach";
+    rel:childOf <#FheighlimRechtmhuir>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CuindCetchathaig>.
+
+<#FheighlimRechtmhuir>
+    a foaf:Person;
+    irishRel:genName "Fheighlim Rechtmhuir";
+    irishRel:nomName "Feidlimid Rechtmar";
+    rel:childOf <#TuathailTechtmhuir>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FheidlimidRechtada>.
+
+<#TuathailTechtmhuir>
+    a foaf:Person;
+    irishRel:genName "Tuathail Techtmar";
+    irishRel:nomName "Tuathal Techtmar";
+    rel:childOf <#FiachaidhFinnolaidh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#TuathailTectmair>.
+
+<#FiachaidhFinnolaidh>
+    a foaf:Person;
+    irishRel:genName "Fiachaidh Finnolaidh";
+    irishRel:nomName "Fiacha Finnolaidh";
+    rel:childOf <#FearadhaighFhinnachtnaigh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FhiachachFindfholaid>.
+
+<#FearadhaighFhinnachtnaigh>
+    a foaf:Person;
+    irishRel:genName "Fearadhaigh Fhinnachtnaigh";
+    irishRel:nomName "Feradach Finnachtnach";
+    rel:childOf <#CrimthainnNiaNar>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#FheradaichFindFechtnaig>.
+
+<#CrimthainnNiaNar>
+    a foaf:Person;
+    irishRel:genName "Crimthainn Nia Nar";
+    irishRel:nomName "Crimthann Nia Nar";
+    rel:childOf <#LuigecRiabhnDerg>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#CrimthaindNiadNaire>.
+
+<#LuigecRiabhnDerg>
+    a foaf:Person;
+    irishRel:genName "Luigec Riabh nDerg";
+    irishRel:nomName "Lugaid Riabh nDerg";
+    rdfs:comment "mhic na tri finneamna";
+    rel:childOf <#Bres>, <#Nar>, <#Lothar>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#LugdachRiabn-Derg>.
+
+<#Bres>
+    a foaf:Person;
+    irishRel:nomName "Bres";
+    rel:childOf <#EachachFeligh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Bres>.
+
+<#Nar>
+    a foaf:Person;
+    irishRel:nomName "Nar";
+    rel:childOf <#EachachFeligh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Nar>.
+
+<#Lothar>
+    a foaf:Person;
+    irishRel:nomName "Lothar";
+    rel:childOf <#EachachFeligh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Lothar>.
+
+<#EachachFeligh>
+    a foaf:Person;
+    irishRel:genName "Eachach Feligh";
+    irishRel:nomName "Eochaid Feidligh";
+    rel:childOf <#Finn>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#EchachFeidlig>.
+
+<#Finn>
+    a foaf:Person;
+    irishRel:genName "Finn";
+    irishRel:nomName "Finn";
+    rel:childOf <#Fhinntain>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Find>.
+
+<#Fhinntain>
+    a foaf:Person;
+    irishRel:genName "Fhinntain";
+    irishRel:nomName "Finntan";
+    rel:childOf <#RoighenRuaidh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Fhintain>.
+
+<#RoighenRuaidh>
+    a foaf:Person;
+    irishRel:genName "Roighen Ruaidh";
+    irishRel:nomName "Roghen Ruadh";
+    rel:childOf <#EasamhainEmna>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#RogenRúaid>.
+
+<#EasamhainEmna>
+    a foaf:Person;
+    irishRel:genName "Easamhain Emna";
+    irishRel:nomName "Easamhan Emna";
+    rel:childOf <#Blathachta>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#EssamnaEmna>.
+
+<#Blathachta>
+    a foaf:Person;
+    irishRel:genName "Blathachta";
+    irishRel:nomName "Blathacht";
+    rel:childOf <#LabradhaLuirc>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#Blathechta>.
+
+<#LabradhaLuirc>
+    a foaf:Person;
+    irishRel:genName "Labradha Luirc";
+    irishRel:nomName "Labraid Lorc";
+    rel:childOf <#EnnaAighnigh>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#LabradaL.>.
+
+<#EnnaAighnigh>
+    a foaf:Person;
+    irishRel:genName "Enna Aighnigh";
+    irishRel:nomName "Enna Aighnech";
+    rel:childOf <#AengusaTurmidhTemhrach>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#EnnaAgnig>.
+
+<#AengusaTurmidhTemhrach>
+    a foaf:Person;
+    irishRel:genName "Aengusa Turmidh Temhrach";
+    irishRel:nomName "Aengus Turmech Temhrach";
+    rel:childOf <#EathachAltleathain>;
+    owl:sameAs <http://example.com/LL/rig_ailig.trig#OengusaTurbig>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig#AengusaTurmighThemrach>.
+
+<#EathachAltleathain>
+    a foaf:Person;
+    irishRel:genName "Eathach Altleathain";
+    irishRel:nomName "Eochaid Altleathan";
+    rel:childOf <#OillellaCaisfhiaclaigh>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#EchachAltlethain>.
+
+<#OillellaCaisfhiaclaigh>
+    a foaf:Person;
+    irishRel:genName "Oillella Caisfhiaclaigh";
+    irishRel:nomName "Ailill Casfhiaclach";
+    rel:childOf <#ChunnlaCruaidhchelgaigh>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#AilellaCasfiaclaich>.
+
+<#ChunnlaCruaidhchelgaigh>
+    a foaf:Person;
+    irishRel:genName "Chunnla Cruaidhchelgaigh";
+    rel:childOf <#IarainngleoFathaigh>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#Condlaíd>.
+
+<#IarainngleoFathaigh>
+    a foaf:Person;
+    irishRel:genName "Iarainngleo Fathaigh";
+    irishRel:nomName "Iaranngleo Fathach";
+    rel:childOf <#MelgeMolbaigh>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#h-Eirora>.
+
+<#MelgeMolbaigh>
+    a foaf:Person;
+    irishRel:genName "Melge Molbaigh";
+    rel:childOf <#CobthaighCailBreg>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#Meilge>.
+
+<#CobthaighCailBreg>
+    a foaf:Person;
+    irishRel:genName "Cobthaigh Cail Breg";
+    irishRel:nomName "Cobthach Cael Breg";
+    rel:childOf <#IughaineMhoir>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#CobthaichCóilBreg>.
+
+<#IughaineMhoir>
+    a foaf:Person;
+    irishRel:genName "Iughaine Mhoir";
+    irishRel:nomName "Iughaine Mor";
+    rel:childOf <#EachachBuadhaigh>;
+    owl:sameAs <http://example.com/Rawl_B502/genelach_clainne_colmáin.trig#ÚgaineMáir>.
+
+<#EachachBuadhaigh>
+    a foaf:Person;
+    irishRel:genName "Eachach Buadhaigh";
+    irishRel:nomName "Eochaidh Buadhach";
+    rel:childOf <#DuacLadhgraidh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#EchachBúadaig>.
+
+<#DuacLadhgraidh>
+    a foaf:Person;
+    irishRel:genName "Duac Ladhgraidh";
+    irishRel:nomName "Duach Ladhrach";
+    rel:childOf <#FhiachachTolgraig>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#DuachLadchri>.
+
+<#FhiachachTolgraig>
+    a foaf:Person;
+    irishRel:genName "Fhiachach Tolgraig";
+    irishRel:nomName "Fiacha Tolgrach";
+    rel:childOf <#MuiredhaighBolgraigh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#FíachaigTolcrach>.
+
+<#MuiredhaighBolgraigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhaigh Bolgraigh";
+    irishRel:nomName "Muiredhach Bolgrach";
+    rel:childOf <#ShimoinBric>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#MuredachBolcrach>.
+
+<#ShimoinBric>
+    a foaf:Person;
+    irishRel:genName "Shimon Bric";
+    irishRel:nomName "Simon Brec";
+    rel:childOf <#AedhainGlais>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#SímóinBricc>.
+
+<#AedhainGlais>
+    a foaf:Person;
+    irishRel:genName "Aedhain Glais";
+    irishRel:nomName "Aedhan Glas";
+    rel:childOf <#NuaghadFinnFail>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#ÁidáinGlais>.
+
+<#NuaghadFinnFail>
+    a foaf:Person;
+    irishRel:genName "Nuaghad Finn Fail";
+    irishRel:nomName "Nuada Finn Fail";
+    rel:childOf <#Giallcad>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#NúadatFindsáil>.
+
+<#Giallcad>
+    a foaf:Person;
+    irishRel:genName "Giallcad";
+    irishRel:nomName "Giallcad";
+    rel:childOf <#OllellaOlchain>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Giallchada>.
+
+<#OllellaOlchain>
+    a foaf:Person;
+    irishRel:genName "Ollella Olchain";
+    irishRel:nomName "Ailill Olchan";
+    rel:childOf <#SirrnaSaodlaid>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#AilellaÓlchlóin>.
+
+<#SirrnaSaodlaid>
+    a foaf:Person;
+    irishRel:genName "Sirrna Saodlaid";
+    irishRel:nomName "Sirna Sadlach";
+    rel:childOf <#Dein>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#SírnaiSaeglaig>.
+
+<#Dein>
+    a foaf:Person;
+    irishRel:genName "Dein";
+    irishRel:nomName "Dian";
+    rel:childOf <#Deamail>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Déin>.
+
+<#Deamail>
+    a foaf:Person;
+    irishRel:genName "Deamail";
+    irishRel:nomName "Deamal";
+    rel:childOf <#Roteachtaigh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Demáil>.
+
+<#Roteachtaigh>
+    a foaf:Person;
+    irishRel:genName "Roteachtaigh";
+    irishRel:nomName "Roteachtach";
+    rel:childOf <#Mháein>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Rothechta>.
+
+<#Mháein>
+    a foaf:Person;
+    irishRel:genName "Mháein";
+    irishRel:nomName "Máen";
+    rel:childOf <#AengusaOlmucaigh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Móen>.
+
+<#AengusaOlmucaigh>
+    a foaf:Person;
+    irishRel:genName "Aengusa Olmucaigh";
+    irishRel:nomName "Aengus Olmucach";
+    rel:childOf <#FhiachachLabrainne>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#ÓengusaÓlmucced>.
+
+<#FhiachachLabrainne>
+    a foaf:Person;
+    irishRel:genName "Fhiachach Labrainne";
+    irishRel:nomName "Fiacha Labrainne";
+    rel:childOf <#Smirghaill>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#FiachrachLabraind>.
+
+<#Smirghaill>
+    a foaf:Person;
+    irishRel:genName "Smirghaill";
+    irishRel:nomName "Smirghall";
+    rel:childOf <#Enbhotha>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Smirgnuill>.
+
+<#Enbhotha>
+    a foaf:Person;
+    irishRel:genName "Enbhotha";
+    rel:childOf <#Thighernais>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Inboith>.
+
+<#Thighernais>
+    a foaf:Person;
+    irishRel:genName "Thighernais";
+    irishRel:nomName "Tigernmas";
+    rel:childOf <#Follaigh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Tigernmais>.
+
+<#Follaigh>
+    a foaf:Person;
+    irishRel:genName "Follaigh";
+    irishRel:nomName "Follach";
+    rel:childOf <#Etreoil>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Follaig>.
+
+<#Etreoil>
+    a foaf:Person;
+    irishRel:genName "Etreoil";
+    rel:childOf <#IreoilFaigh>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Hetherél>.
+
+<#IreoilFaigh>
+    a foaf:Person;
+    irishRel:genName "Ireoil Faigh";
+    irishRel:nomName "Irial Fath";
+    rel:childOf <#Ereamoin>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Hirélfáith>.
+
+<#Ereamoin>
+    a foaf:Person;
+    irishRel:genName "Ereamoin";
+    irishRel:nomName "Erimon";
+    rel:childOf <#MileadhEsbaine>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Herimon>.
+
+<#MileadhEsbaine>
+    a foaf:Person;
+    irishRel:genName "Mileadh Esbaine";
+    irishRel:nomName "Mile Esbaine";
+    rel:childOf <#Bile>;
+    owl:sameAs <http://example.com/Laud_Misc_610/CGH/_1.trig#Militis>.
+
+<#Bile>
+    a foaf:Person;
+    irishRel:genName "Bile";
+    irishRel:nomName "Bile";
+    rel:childOf <#Breoghain>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Bile>.
+
+<#Breoghain>
+    a foaf:Person;
+    irishRel:genName "Breoghain";
+    irishRel:nomName "Breoghan";
+    rel:childOf <#Bratha>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Bregain>.
+
+<#Bratha>
+    a foaf:Person;
+    irishRel:genName "Bratha";
+    rel:childOf <#Deatha>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Brátha>.
+
+<#Deatha>
+    a foaf:Person;
+    irishRel:genName "Deatha";
+    rel:childOf <#Erchadha>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Deátha>.
+
+<#Erchadha>
+    a foaf:Person;
+    irishRel:genName "Erchadha";
+    rel:childOf <#Alloid>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Airceda>.
+
+<#Alloid>
+    a foaf:Person;
+    irishRel:genName "Alloid";
+    rel:childOf <#Nuaghad>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Alldóit-78807a44>.
+
+<#Nuaghad>
+    a foaf:Person;
+    irishRel:genName "Nuaghad";
+    irishRel:nomName "Nuada";
+    rel:childOf <#Naenuail>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Nuadat-f5c9b7b0>.
+
+<#Naenuail>
+    a foaf:Person;
+    irishRel:genName "Naenuail";
+    rel:childOf <#EbirGhlais>;
+    owl:sameAs <http://example.com/Rawl_B502/geneleach_osrithe.trig#Nóenail>.
+
+<#EbirGhlais>
+    a foaf:Person;
+    irishRel:genName "Ebir Ghlais";
+    irishRel:nomName "Eber Glas";
+    rel:childOf <#EbirGlunfhinn>;
+    owl:sameAs <http://example.com/LL/section_135.trig#FhebriGlais>.
+
+<#EbirGlunfhinn>
+    a foaf:Person;
+    irishRel:genName "Ebir Glunfhinn";
+    irishRel:nomName "Eber Glunfhinn";
+    rel:childOf <#Laimfhinn>;
+    owl:sameAs <http://example.com/LL/section_135.trig#EbirGlunfhind>.
+
+<#Laimfhinn>
+    a foaf:Person;
+    irishRel:genName "Laimfhinn";
+    irishRel:nomName "Lamfinn";
+    rel:childOf <#AghnoinFhinn>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Lamfhind>.
+
+<#AghnoinFhinn>
+    a foaf:Person;
+    irishRel:genName "Aghnoin Fhinn";
+    irishRel:nomName "Aghnon Finn";
+    rel:childOf <#Thait>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Agnoman>.
+
+<#Thait>
+    a foaf:Person;
+    irishRel:genName "Thait";
+    irishRel:nomName "Tat";
+    rel:childOf <#Oghomhain>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Thait>.
+
+<#Oghomhain>
+    a foaf:Person;
+    irishRel:genName "Oghomhain";
+    irishRel:nomName "Oghomhan";
+    rel:childOf <#Beoghomain>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Ogamain>.
+
+<#Beoghomain>
+    a foaf:Person;
+    irishRel:genName "Beoghomain";
+    irishRel:nomName "Beoghoman";
+    rel:childOf <#EbirScuit>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Beomain>.
+
+<#EbirScuit>
+    a foaf:Person;
+    irishRel:genName "Ebir Scuit";
+    rel:childOf <#Shruib>;
+    owl:sameAs <http://example.com/LL/section_135.trig#EbirScuit>.
+
+<#Shruib>
+    a foaf:Person;
+    irishRel:genName "Shruib";
+    irishRel:nomName "Srub";
+    rel:childOf <#Esruib>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Sru>.
+
+<#Esruib>
+    a foaf:Person;
+    irishRel:genName "Esruib";
+    irishRel:nomName "Esrub";
+    rel:childOf <#GaeighilGlais>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Esrú>.
+
+<#GaeighilGlais>
+    a foaf:Person;
+    irishRel:genName "Gaeighil Glais";
+    irishRel:nomName "Gaeighel Glas";
+    rel:childOf <#Niuil>;
+    owl:sameAs <http://example.com/LL/section_135.trig#GaidilGlais>.
+
+<#Niuil>
+    a foaf:Person;
+    irishRel:genName "Niuil";
+    irishRel:nomName "Nel";
+    rel:childOf <#FeniusFarsaigh>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Niúil>.
+
+<#FeniusFarsaigh>
+    a foaf:Person;
+    irishRel:genName "Fenius Farsaigh";
+    rel:childOf <#Baadh>;
+    owl:sameAs <http://example.com/LL/section_135.trig#FhaeniusaFarsaid>.
+
+<#Baadh>
+    a foaf:Person;
+    irishRel:genName "Baadh";
+    rel:childOf <#Badhog>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Baatha>.
+
+<#Badhog>
+    a foaf:Person;
+    irishRel:genName "Badhog";
+    rdfs:comment "mbraithre thaid";
+    rel:childOf <#Goimer>.
+    #The note is difficult to read and of unclear meaning. - EPT
+
+<#Goimer>
+    a foaf:Person;
+    irishRel:genName "Goimer";
+    rel:childOf <#Iafeth>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Gomer>.
+
+<#Iafeth>
+    a foaf:Person;
+    irishRel:genName "Iafeth";
+    rel:childOf <#Naeí>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Iafeth>.
+
+<#Naeí>
+    a foaf:Person;
+    irishRel:genName "Naeí";
+    rel:childOf <#Laimfhiach>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Noe>.
+
+<#Laimfhiach>
+    a foaf:Person;
+    irishRel:genName "Laimfhiach";
+    rel:childOf <#Mathasalam>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Lamiach>.
+
+<#Mathasalam>
+    a foaf:Person;
+    irishRel:genName "Mathasalam";
+    rel:childOf <#Enog>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Mathusalem>.
+
+<#Enog>
+    a foaf:Person;
+    irishRel:genName "Enog";
+    rel:childOf <#Iareth>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Enoc>.
+
+<#Iareth>
+    a foaf:Person;
+    irishRel:genName "Iareth";
+    rel:childOf <#Malalel>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Iareth>.
+
+<#Malalel>
+    a foaf:Person;
+    irishRel:genName "Malalel";
+    rel:childOf <#Canain>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Malalel>.
+
+<#Canain>
+    a foaf:Person;
+    irishRel:genName "Canain";
+    rel:childOf <#Enois>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Cainain>.
+
+<#Enois>
+    a foaf:Person;
+    irishRel:genName "Enois";
+    rel:childOf <#Seth>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Enos>.
+
+<#Seth>
+    a foaf:Person;
+    irishRel:genName "Seth";
+    rel:childOf <#Adhaim>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Seth>.
+
+<#Adhaim>
+    a foaf:Person;
+    irishRel:genName "Adhaim";
+    rel:childOf <#DeBí>;
+    owl:sameAs <http://example.com/LL/section_135.trig#Adaim>.
+
+<#DeBí>
+    a foaf:Person;
+    irishRel:genName "De Bí";
+    owl:sameAs <http://example.com/LL/section_135.trig#DéBí>;
+    rdfs:comment "et ni fil enduine suas uadha sin acht dia uilecumachtach".
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Mhic Domnaill annso"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred%2035a%201vd%201-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>.
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred%2035a%201vd%201-57.html>, <https://www.1467manuscript.co.uk/kindred%2035b%201-57.html>.
 
 <#Eoin>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
@@ -1,0 +1,25 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Domnaill annso"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/Kindred 35a 1vd 1-57.html> .
+
+
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
@@ -39,7 +39,9 @@
     irishRel:nomName "Domnall";
     rel:childOf <#Eoin-b674fe50>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q3036052>.
-    #Sic. The nominative form appears for the genitive in the MS. - EPT
+    << <#Domnall>
+          rdfs:comment "Sic. The nominative form appears for the genitive in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eoin-b674fe50>
     a foaf:Person;
@@ -686,7 +688,9 @@
     irishRel:genName "Badhog";
     rdfs:comment "mbraithre thaid";
     rel:childOf <#Goimer>.
-    #The note is difficult to read and of unclear meaning. - EPT
+    << <#Badhog>
+          rdfs:comment "The note is difficult to read and of unclear meaning." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Goimer>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_35.trig
@@ -24,7 +24,7 @@
     a foaf:Person;
     irishRel:nomName "Eoin";
     rel:childOf <#Alasdair>;
-    rdfs:seeAlso <https://www.wikidata.org/entity/Q3172627>
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3172627>.
 
 <#Alasdair>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Kindred 4"@sga;
+    dcterms:title "Genelach Mhic Nechtain"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2004.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2004.html> .

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
@@ -117,7 +117,7 @@
     irishRel:genName "Imhair";
     irishRel:nomName "Imhar";
     rel:childOf <#NeachtainOig>.
-    << <#Aenghusa>
+    << <#Imhair>
           rdfs:comment "This name is marked in the MS; Black suggests that it is to be swapped with 'Aenghusa'." >>
           prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
@@ -108,16 +108,18 @@
     irishRel:genName "Aenghusa";
     irishRel:nomName "Aenghus";
     rel:childOf <#Imhair>.
-    #This name is marked in the MS; Black suggests that it is to be swapped
-    # with "Imhair". - EPT
+    << <#Aenghusa>
+          rdfs:comment "This name is marked in the MS; Black suggests that it is to be swapped with 'Imhair'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Imhair>
     a foaf:Person;
     irishRel:genName "Imhair";
     irishRel:nomName "Imhar";
     rel:childOf <#NeachtainOig>.
-    #This name is marked in the MS; Black suggests that it is to be swapped
-    # with "Aenghusa". - EPT
+    << <#Aenghusa>
+          rdfs:comment "This name is marked in the MS; Black suggests that it is to be swapped with 'Aenghusa'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#NeachtainOig>
     a foaf:Person;
@@ -191,7 +193,9 @@
     irishRel:nomName "Eochu";
     rel:childOf <#Muiredhaigh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Eathhach>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eathach>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Muiredhaigh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig
@@ -1,0 +1,224 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 4"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2004.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2004.html> .
+
+<#Muiris>
+    a foaf:Person;
+    irishRel:nomName "Muiris";
+    rel:childOf <#MaelColaim>.
+
+<#MaelColaim>
+    a foaf:Person;
+    irishRel:genName "Mael Colaim";
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#Muiris>.
+
+<#Muiris-20ab7930>
+    a foaf:Person;
+    irishRel:genName "Muiris";
+    irishRel:nomName "Muiris";
+    rel:childOf <#MaelColaim-20ab7930>.
+
+<#MaelColaim-20ab7930>
+    a foaf:Person;
+    irishRel:genName "Mael Colaim";
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#Gibuin>.
+
+<#Gibuin>
+    a foaf:Person;
+    irishRel:genName "Gibuin";
+    irishRel:nomName "Gibun";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Domhnaill>.
+
+<#Domhnaill>
+    a foaf:Person;
+    irishRel:genName "Domhnaill";
+    irishRel:nomName "Domhnall";
+    rel:childOf <#Neachtain>.
+
+<#Neachtain>
+    a foaf:Person;
+    irishRel:genName "Neachtain";
+    irishRel:nomName "Neachtan";
+    rel:childOf <#Artuir>.
+
+<#Artuir>
+    a foaf:Person;
+    irishRel:genName "Neachtain";
+    irishRel:nomName "Neachtan";
+    rel:childOf <#Gibuin-d0a9cb70>.
+
+<#Gibuin-d0a9cb70>
+    a foaf:Person;
+    irishRel:genName "Gibuin";
+    irishRel:nomName "Gibun";
+    rel:childOf <#Nechtain>.
+
+<#Nechtain>
+    a foaf:Person;
+    irishRel:genName "Nechtain";
+    irishRel:nomName "Nechtan";
+    rel:childOf <#Isog>.
+
+<#Isog>
+    a foaf:Person;
+    irishRel:genName "Isog";
+    irishRel:nomName "Isog";
+    rel:childOf <#GillaMartain>.
+
+<#GillaMartain>
+    a foaf:Person;
+    irishRel:genName "Gilla Martain";
+    irishRel:nomName "Gilla Martain";
+    rel:childOf <#Aenghusa>.
+
+<#Aenghusa>
+    a foaf:Person;
+    irishRel:genName "Aenghusa";
+    irishRel:nomName "Aenghus";
+    rel:childOf <#Imhair>.
+    #This name is marked in the MS; Black suggests that it is to be swapped
+    # with "Imhair". - EPT
+
+<#Imhair>
+    a foaf:Person;
+    irishRel:genName "Imhair";
+    irishRel:nomName "Imhar";
+    rel:childOf <#NeachtainOig>.
+    #This name is marked in the MS; Black suggests that it is to be swapped
+    # with "Aenghusa". - EPT
+
+<#NeachtainOig>
+    a foaf:Person;
+    irishRel:genName "Neachtain Oig";
+    irishRel:nomName "Neachtan Og";
+    rel:childOf <#NechtainMedhin>.
+
+<#NechtainMedhin>
+    a foaf:Person;
+    irishRel:genName "Nechtain Medhin";
+    irishRel:nomName "Nechtan Medhon";
+    rel:childOf <#NechtainMhoir>.
+
+<#NechtainMhoir>
+    a foaf:Person;
+    irishRel:genName "Nechtain Mhoir";
+    irishRel:nomName "Nechtan Mor";
+    rel:childOf <#DomnaillDuinn>.
+
+<#DomnaillDuinn>
+    a foaf:Person;
+    irishRel:genName "Domnaill Duinn";
+    irishRel:nomName "Domnall Donn";
+    rel:childOf <#FerchairFhada>.
+
+<#FerchairFhada>
+    a foaf:Person;
+    irishRel:genName "Ferchair Fhada";
+    irishRel:nomName "Ferchar Fada";
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradhach";
+    rel:childOf <#Ferghusa>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+<#Ferghusa>
+    a foaf:Person;
+    irishRel:genName "Ferghusa";
+    irishRel:nomName "Ferghus";
+    rel:childOf <#Nechtain-15ed28c0>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fergusa>.
+
+<#Nechtain-15ed28c0>
+    a foaf:Person;
+    irishRel:genName "Ferghusa";
+    irishRel:nomName "Ferghus";
+    rel:childOf <#Colmain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Shneachtain>.
+
+<#Colmain>
+    a foaf:Person;
+    irishRel:genName "Colmain";
+    irishRel:nomName "Colman";
+    rel:childOf <#Buadain>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Colmain>.
+
+<#Buadain>
+    a foaf:Person;
+    irishRel:genName "Buadain";
+    irishRel:nomName "Buadan";
+    rel:childOf <#Eathach>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Buadain>.
+
+<#Eathach>
+    a foaf:Person;
+    irishRel:genName "Eathach";
+    irishRel:nomName "Eochu";
+    rel:childOf <#Muiredhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Eathhach>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Muiredhaigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhaigh";
+    irishRel:nomName "Muiredhach";
+    rel:childOf <#LoairnMoir>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Muiredhaigh>.
+
+<#LoairnMoir>
+    a foaf:Person;
+    irishRel:genName "Loairn Moir";
+    irishRel:nomName "Loarn Mor";
+    rel:childOf <#Eirc>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#LoairnMair>.
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#EchachMuinreamair>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig#Eirc>.
+
+<#EchachMuinreamair>
+    a foaf:Person;
+    irishRel:genName "Echach Muinreamair";
+    irishRel:nomName "Eochu Muinreamar";
+    rel:childOf <#EchachMuinreamair>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_1.trig#EathachMuinnremair>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -24,15 +24,17 @@
     a foaf:Person;
     irishRel:nomName "Uilliam";
     rel:childOf <#Uilliam-ccea1240>.
-    #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene, backed up by spectral imaging. - EPT
+    << <#Uilliam>
+          rdfs:comment "The relevant section of the MS is now difficult to read and this relies on an earlier transcription by W. F. Skene, backed up by spectral imaging." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Domnall>
     a foaf:Person;
     irishRel:nomName "Domnall";
     rel:childOf <#Uilliam-ccea1240>.
-    #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene, backed up by spectral imaging. - EPT
+    << <#Domnall>
+          rdfs:comment "The relevant section of the MS is now difficult to read and this relies on an earlier transcription by W. F. Skene, backed up by spectral imaging." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Uilliam-ccea1240>
     a foaf:Person;
@@ -68,46 +70,53 @@
     a foaf:Person;
     irishRel:genName "Oisiab";
     rel:childOf <#GillaCrist>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Oisiab>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaCrist>
     a foaf:Person;
     irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
     rel:childOf <#Aigcob>.
-    #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
+    << <#GillaCrist>
+          rdfs:comment "The relevant section of the MS is now difficult to read and this relies on an earlier transcription by W. F. Skene, backed up with spectral imaging." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Aigcob>
     a foaf:Person;
     irishRel:genName "Aigcob";
     rel:childOf <#Eogain>.
-    #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
+    << <#Aigcob>
+          rdfs:comment "The relevant section of the MS is now difficult to read and this relies on an earlier transcription by W. F. Skene, backed up with spectral imaging." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eogain>
     a foaf:Person;
     irishRel:genName "Eogain";
     irishRel:nomName "Eogan";
     rel:childOf <#Poil>.
-    #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
+    << <#Eogain>
+          rdfs:comment "The relevant section of the MS is now difficult to read and this relies on an earlier transcription by W. F. Skene, backed up with spectral imaging." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Poil>
     a foaf:Person;
     irishRel:genName "Poil";
     irishRel:nomName "Pol";
     rel:childOf <#NeillLachlannaigh>.
-    #This name is difficult to read in the MS. Even spectral imaging fails to reveal more
-    #than the final two letters. Black hypothesises "Poil" based on the lack of any other
-    #known name that would fit. - EPT
+    << <#Poil>
+          rdfs:comment "This name is difficult to read in the MS. Even spectral imaging fails to reveal more than the final two letters. Black hypothesises 'Poil' based on the lack of any other known name that would fit." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#NeillLachlannaigh>
     a foaf:Person;
     irishRel:genName "Neill Lachlannaigh";
     irishRel:nomName "Niall Lachlannach";
     rel:childOf <#Suibne>.
-    #This name is difficult to read in the MS. - EPT
+    << <#NeillLachlannaigh>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Suibne>
     a foaf:Person;
@@ -125,7 +134,9 @@
     irishRel:genName "Leoid";
     irishRel:nomName "Leod";
     rel:childOf <#tSead>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Leoid>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#tSead>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Do Genelach Cloinni an Toisigh .i. Clann Gilla Chatan"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2005.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2005.html>,  <https://www.1467manuscript.co.uk/MackintoshDec2020.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2005.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2005.html>, <https://www.1467manuscript.co.uk/MackintoshDec2020.pdf>.
 
 <#Uilliam>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -8,6 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 
 
 
@@ -211,7 +212,7 @@
     rel:childOf <#Diarmada>.
 
 <#Diarmada>
-    a IrishTitles:FerLéiginn;
+    a IrishTitle:FerLéiginn;
     irishRel:genName "Diarmada";
     irishRel:nomName "Diarmaid";
     rdfs:comment "re nabartha an fer leiginn";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -1,0 +1,225 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 5"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2005.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2005.html> .
+
+<#Uilliam>
+    a foaf:Person;
+    irishRel:nomName "Uilliam";
+    rel:childOf <#Uilliam-ccea1240>.
+    #The relevant section of the MS is now difficult to read and this relies on
+    #an earlier transcription by W. F. Skene.
+
+<#Domnall>
+    a foaf:Person;
+    irishRel:nomName "Domnall";
+    rel:childOf <#Uilliam-ccea1240>.
+    #The relevant section of the MS is now difficult to read and this relies on
+    #an earlier transcription by W. F. Skene.
+
+<#Uilliam-ccea1240>
+    a foaf:Person;
+    irishRel:genName "Uilliam";
+    irishRel:nomName "Uilliam";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Uilliam-2c0266b0>.
+
+<#Uilliam-2c0266b0>
+    a foaf:Person;
+    irishRel:genName "Uilliam";
+    irishRel:nomName "Uilliam";
+    rel:childOf <#GillaMichil>.
+
+<#GillaMichil>
+    a foaf:Person;
+    irishRel:genName "Gilla Michil";
+    irishRel:nomName "Gilla Michil";
+    rel:childOf <#Ferchair-589efe90>.
+
+<#Ferchair-589efe90>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Oisiab>.
+
+<#Oisiab>
+    a foaf:Person;
+    irishRel:genName "Oisiab";
+    rel:childOf <#GillaCrist>.
+    #This name is difficult to read in the MS. - EPT
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Aigcol>.
+    #The relevant section of the MS is now difficult to read and this relies on
+    #an earlier transcription by W. F. Skene.
+
+<#Aigcol>
+    a foaf:Person;
+    irishRel:genName "Aigcol";
+    rel:childOf <#Eogain>.
+    #The relevant section of the MS is now difficult to read and this relies on
+    #an earlier transcription by W. F. Skene.
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#Pal>.
+    #The relevant section of the MS is now difficult to read and this relies on
+    #an earlier transcription by W. F. Skene.
+
+<#Pal>
+    a foaf:Person;
+    irishRel:genName "Pal";
+    irishRel:nomName "Pal";
+    rel:childOf <#NeillLachlanaig>.
+    #This name is difficult to read in the MS. - EPT
+
+<#NeillLachlanaig>
+    a foaf:Person;
+    irishRel:genName "Neill Lachlanaig";
+    irishRel:nomName "Niall Lachlanach";
+    rel:childOf <#Suibne>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Suibne>
+    a foaf:Person;
+    irishRel:genName "Suibne";
+    irishRel:nomName "Suibne";
+    rel:childOf <#Oisiab-1ead0d20>.
+
+<#Oisiab-1ead0d20>
+    a foaf:Person;
+    irishRel:genName "Oisiab";
+    rel:childOf <#Leoid>.
+
+<#Leoid>
+    a foaf:Person;
+    irishRel:genName "Leoid";
+    irishRel:nomName "Leod";
+    rel:childOf <#tSead>.
+
+<#tSead>
+    a foaf:Person;
+    irishRel:genName "tSead";
+    rel:childOf <#Ferchair-5e8a3bc0>.
+
+<#Ferchair-5e8a3bc0>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#GillaCrist-780bc640>.
+
+<#GillaCrist-780bc640>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#MaeilColaim>.
+
+<#MaeilColaim>
+    a foaf:Person;
+    irishRel:genName "Maeil Colaim";
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#Domnaill>.
+
+<#Domnaill>
+    a foaf:Person;
+    irishRel:genName "Domnaill";
+    irishRel:nomName "Domnall";
+    rdfs:comment "re nabartha in caimgilla";
+    rel:childOf <#Murchaidh>.
+
+<#Murchaidh>
+    a foaf:Person;
+    irishRel:genName "Murchaidh";
+    irishRel:nomName "Murchadh";
+    rel:childOf <#Shuibne>.
+
+<#Shuibne>
+    a foaf:Person;
+    irishRel:genName "Shuibne";
+    irishRel:nomName "Suibne";
+    rel:childOf <#Theadh>.
+
+<#Theadh>
+    a foaf:Person;
+    irishRel:genName "Theadh";
+    rel:childOf <#Neachtain>.
+
+<#Neachtain>
+    a foaf:Person;
+    irishRel:genName "Neachtain";
+    irishRel:nomName "Neachtan";
+    rel:childOf <#GillaChatain>.
+
+<#GillaChatain>
+    a foaf:Person;
+    irishRel:genName "Gilla Chatain";
+    irishRel:nomName "Gilla Catain";
+    rdfs:comment "o fuilid Clann Gilla Catain";
+    rel:childOf <#Gallbrait>.
+
+<#Gallbrait>
+    a foaf:Person;
+    irishRel:genName "Gallbrait";
+    irishRel:nomName "Gallbrat";
+    rel:childOf <#Diarmada>.
+
+<#Diarmada>
+    a foaf:Person;
+    irishRel:genName "Diarmada";
+    irishRel:nomName "Diarmaid";
+    rdfs:comment "re nabartha an fer leiginn";
+    foaf:title "fer léiginn"@sga, "scholar"@eng;
+    rel:childOf <#Erc>.
+
+<#Erc>
+    a foaf:Person;
+    irishRel:genName "Erc";
+    irishRel:nomName "Erc";
+    rel:childOf <#Conlaith>.
+
+<#Conlaith>
+    a foaf:Person;
+    irishRel:genName "Conlaith";
+    rel:childOf <#FerchairFhota>.
+
+<#FerchairFhota>
+    a foaf:Person;
+    irishRel:genName "Ferchair Fhota";
+    irishRel:nomName "Ferchar Fota";
+    rel:childOf <#Fearadaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+
+<#Fearadaigh>
+    a foaf:Person;
+    irishRel:genName "Fearadaigh";
+    irishRel:nomName "Fearadach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Kindred 5"@sga;
+    dcterms:title "Do Genelach Cloinni an Toisigh"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2005.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2005.html> .

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -200,7 +200,7 @@
     rel:childOf <#Diarmada>.
 
 <#Diarmada>
-    a foaf:Person;
+    a IrishTitles:FerLéiginn;
     irishRel:genName "Diarmada";
     irishRel:nomName "Diarmaid";
     rdfs:comment "re nabartha an fer leiginn";

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_5.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Do Genelach Cloinni an Toisigh"@sga;
+    dcterms:title "Do Genelach Cloinni an Toisigh .i. Clann Gilla Chatan"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2005.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2005.html> .
@@ -25,14 +25,14 @@
     irishRel:nomName "Uilliam";
     rel:childOf <#Uilliam-ccea1240>.
     #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene.
+    #an earlier transcription by W. F. Skene, backed up by spectral imaging. - EPT
 
 <#Domnall>
     a foaf:Person;
     irishRel:nomName "Domnall";
     rel:childOf <#Uilliam-ccea1240>.
     #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene.
+    #an earlier transcription by W. F. Skene, backed up by spectral imaging. - EPT
 
 <#Uilliam-ccea1240>
     a foaf:Person;
@@ -74,36 +74,38 @@
     a foaf:Person;
     irishRel:genName "Gilla Crist";
     irishRel:nomName "Gilla Crist";
-    rel:childOf <#Aigcol>.
+    rel:childOf <#Aigcob>.
     #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene.
+    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
 
-<#Aigcol>
+<#Aigcob>
     a foaf:Person;
-    irishRel:genName "Aigcol";
+    irishRel:genName "Aigcob";
     rel:childOf <#Eogain>.
     #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene.
+    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
 
 <#Eogain>
     a foaf:Person;
     irishRel:genName "Eogain";
     irishRel:nomName "Eogan";
-    rel:childOf <#Pal>.
+    rel:childOf <#Poil>.
     #The relevant section of the MS is now difficult to read and this relies on
-    #an earlier transcription by W. F. Skene.
+    #an earlier transcription by W. F. Skene, backed up with spectral imaging. - EPT
 
-<#Pal>
+<#Poil>
     a foaf:Person;
-    irishRel:genName "Pal";
-    irishRel:nomName "Pal";
-    rel:childOf <#NeillLachlanaig>.
-    #This name is difficult to read in the MS. - EPT
+    irishRel:genName "Poil";
+    irishRel:nomName "Pol";
+    rel:childOf <#NeillLachlannaigh>.
+    #This name is difficult to read in the MS. Even spectral imaging fails to reveal more
+    #than the final two letters. Black hypothesises "Poil" based on the lack of any other
+    #known name that would fit. - EPT
 
-<#NeillLachlanaig>
+<#NeillLachlannaigh>
     a foaf:Person;
-    irishRel:genName "Neill Lachlanaig";
-    irishRel:nomName "Niall Lachlanach";
+    irishRel:genName "Neill Lachlannaigh";
+    irishRel:nomName "Niall Lachlannach";
     rel:childOf <#Suibne>.
     #This name is difficult to read in the MS. - EPT
 
@@ -123,6 +125,7 @@
     irishRel:genName "Leoid";
     irishRel:nomName "Leod";
     rel:childOf <#tSead>.
+    #This name is difficult to read in the MS. - EPT
 
 <#tSead>
     a foaf:Person;
@@ -164,11 +167,12 @@
     a foaf:Person;
     irishRel:genName "Shuibne";
     irishRel:nomName "Suibne";
-    rel:childOf <#Theadh>.
+    rel:childOf <#Sheadh>.
 
-<#Theadh>
+<#Sheadh>
     a foaf:Person;
     irishRel:genName "Theadh";
+    irishRel:nomName "Seth";
     rel:childOf <#Neachtain>.
 
 <#Neachtain>
@@ -182,7 +186,12 @@
     irishRel:genName "Gilla Chatain";
     irishRel:nomName "Gilla Catain";
     rdfs:comment "o fuilid Clann Gilla Catain";
+    irishRel:ancestorOfGroup <#ClannGillaCatain>;
     rel:childOf <#Gallbrait>.
+
+<#ClannGillaCatain>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Gilla Catain".
 
 <#Gallbrait>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Kindred 6"@sga;
+    dcterms:title "Do Ghenelach Mhic an Aba Uathne"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2006.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2006.html> .

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Do Ghenelach Mhic an Aba Uathne"@sga;
+    dcterms:title "Do Ghenelach Mhic an Aba Uaine"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2006.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2006.html> .
@@ -23,18 +23,18 @@
 <#GillaMuire>
     a foaf:Person;
     irishRel:nomName "Gilla Muire";
-    rel:childOf <#EoghainMoir>.
+    rel:childOf <#EoinMoir>.
 
-<#EoghainMoir>
+<#EoinMoir>
     a foaf:Person;
-    irishRel:genName "Eoghain Moir";
-    irishRel:nomName "Eoghan Mor";
+    irishRel:genName "Eoin Moir";
+    irishRel:nomName "Eoin Mor";
     rel:childOf <#Aenghusa>.
 
 <#Aenghusa>
     a foaf:Person;
     irishRel:genName "Aenghusa";
-    irishRel:nomName "Aengus";
+    irishRel:nomName "Aenghus";
     rel:childOf <#MhicBethad>.
 
 <#MhicBethad>
@@ -46,7 +46,7 @@
 <#Aenghusa-166e0d30>
     a foaf:Person;
     irishRel:genName "Aenghusa";
-    irishRel:nomName "Aengus";
+    irishRel:nomName "Aenghus";
     rel:childOf <#GillaMuireLongaigh>.
 
 <#GillaMuireLongaigh>
@@ -71,11 +71,12 @@
     a foaf:Person;
     irishRel:genName "Donnchaidh";
     irishRel:nomName "Donnchadh";
-    rel:childOf <#Firthire>.
+    rel:childOf <#FirThire>.
 
-<#Firthire>
+<#FirThire>
     a foaf:Person;
-    irishRel:genName "Firthire";
+    irishRel:genName "Fir Thire";
+    irishRel:nomName "Fer Tire";
     rel:childOf <#GillaFaelain>.
 
 <#GillaFaelain>
@@ -88,12 +89,12 @@
     a foaf:Person;
     irishRel:genName "Gilla Mhartainn";
     irishRel:nomName "Gilla Martainn";
-    rel:childOf <#FirThead>.
+    rel:childOf <#FirTheadh>.
 
-<#FirThead>
+<#FirTheadh>
     a foaf:Person;
-    irishRel:genName "Fir Thead";
-    irishRel:nomName "Fer Tead";
+    irishRel:genName "Fir Theadh";
+    irishRel:nomName "Fer Teadh";
     rel:childOf <#Loairn>.
 
 <#Loairn>
@@ -130,15 +131,14 @@
     a foaf:Person;
     irishRel:genName "Domnaill Duinn";
     irishRel:nomName "Domnall Donn";
-    rel:childOf <#FerchairAbradruaidh>;
+    rel:childOf <#FerchairAbradruadh>;
     owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig#DomnaillDuinn>.
 
-<#FerchairAbradruaidh>
+<#FerchairAbradruadh>
     a foaf:Person;
-    irishRel:genName "Ferchair Abradruaidh";
+    irishRel:genName "Ferchair Abradruadh";
     irishRel:nomName "Ferchar Abradruadh";
-    rel:childOf <#Feradhaigh>;
-    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+    rel:childOf <#Feradhaigh>.
 
 <#Feradhaigh>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
@@ -1,0 +1,149 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Kindred 6"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2006.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2006.html> .
+
+<#GillaMuire>
+    a foaf:Person;
+    irishRel:nomName "Gilla Muire";
+    rel:childOf <#EoghainMoir>.
+
+<#EoghainMoir>
+    a foaf:Person;
+    irishRel:genName "Eoghain Moir";
+    irishRel:nomName "Eoghan Mor";
+    rel:childOf <#Aenghusa>.
+
+<#Aenghusa>
+    a foaf:Person;
+    irishRel:genName "Aenghusa";
+    irishRel:nomName "Aengus";
+    rel:childOf <#MhicBethad>.
+
+<#MhicBethad>
+    a foaf:Person;
+    irishRel:genName "Mhic Bethad";
+    irishRel:nomName "Mac Bethad";
+    rel:childOf <#Aenghusa-166e0d30>.
+
+<#Aenghusa-166e0d30>
+    a foaf:Person;
+    irishRel:genName "Aenghusa";
+    irishRel:nomName "Aengus";
+    rel:childOf <#GillaMuireLongaigh>.
+
+<#GillaMuireLongaigh>
+    a foaf:Person;
+    irishRel:genName "Gilla Muire Longaigh";
+    irishRel:nomName "Gilla Muire Longach";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Fhinnlaeich>.
+
+<#Fhinnlaeich>
+    a foaf:Person;
+    irishRel:genName "Fhinnlaeich";
+    irishRel:nomName "Finnlaech";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#Firthire>.
+
+<#Firthire>
+    a foaf:Person;
+    irishRel:genName "Firthire";
+    rel:childOf <#GillaFaelain>.
+
+<#GillaFaelain>
+    a foaf:Person;
+    irishRel:genName "Gilla Faelain";
+    irishRel:nomName "Gilla Faelain";
+    rel:childOf <#GillaMhartainn>.
+
+<#GillaMhartainn>
+    a foaf:Person;
+    irishRel:genName "Gilla Mhartainn";
+    irishRel:nomName "Gilla Martainn";
+    rel:childOf <#FirThead>.
+
+<#FirThead>
+    a foaf:Person;
+    irishRel:genName "Fir Thead";
+    irishRel:nomName "Fer Tead";
+    rel:childOf <#Loairn>.
+
+<#Loairn>
+    a foaf:Person;
+    irishRel:genName "Loairn";
+    irishRel:nomName "Loarn";
+    rel:childOf <#Ferchair-d5125f70>.
+
+<#Ferchair-d5125f70>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Oirbertaigh>.
+
+<#Oirbertaigh>
+    a foaf:Person;
+    irishRel:genName "Oirbertaigh";
+    irishRel:nomName "Oibertach";
+    rel:childOf <#Erc>.
+
+<#Erc>
+    a foaf:Person;
+    irishRel:genName "Erc";
+    irishRel:nomName "Erc";
+    rel:childOf <#DomnaillDuinn>.
+
+<#DomnaillDuinn>
+    a foaf:Person;
+    irishRel:genName "Domnaill Duinn";
+    irishRel:nomName "Domnall Donn";
+    rel:childOf <#FerchairAbradruaidh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_4.trig#DomnaillDuinn>.
+
+<#FerchairAbradruaidh>
+    a foaf:Person;
+    irishRel:genName "Ferchair Abradruaidh";
+    irishRel:nomName "Ferchar Abradruadh";
+    rel:childOf <#Feradhaigh>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+
+<#Feradhaigh>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh";
+    irishRel:nomName "Feradhach";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_6.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Do Ghenelach Mhic an Aba Uaine"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2006.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2006.html>, <https://www.1467manuscript.co.uk/GreenAbbottBlack%20BLACKforWEB.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2006.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2006.html>, <https://www.1467manuscript.co.uk/GreenAbbottBlack%20BLACKforWEB.pdf>.
 
 <#GillaMuire>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig
@@ -1,0 +1,114 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Griogair"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2007.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2007.html> .
+
+<#MaelColaim>
+    a foaf:Person;
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#Padraic>.
+
+<#Padraic>
+    a foaf:Person;
+    irishRel:genName "Padraic";
+    irishRel:nomName "Padraic";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Grigair>.
+
+<#Grigair>
+    a foaf:Person;
+    irishRel:genName "Grigair";
+    irishRel:nomName "Grigar";
+    rel:childOf <#Donnchaidh>.
+
+<#Donnchaidh>
+    a foaf:Person;
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf <#MaeilColaim>.
+
+<#MaeilColaim>
+    a foaf:Person;
+    irishRel:genName "Maeil Colaim";
+    irishRel:nomName "Mael Colaim";
+    rel:childOf <#GillaCrist>.
+
+<#GillaCrist>
+    a foaf:Person;
+    irishRel:genName "Gilla Crist";
+    irishRel:nomName "Gilla Crist";
+    rel:childOf <#Ferchair>.
+
+<#Ferchair>
+    a foaf:Person;
+    irishRel:genName "Ferchair";
+    irishRel:nomName "Ferchar";
+    rel:childOf <#Muiredhaigh>.
+
+<#Muiredhaigh>
+    a foaf:Person;
+    irishRel:genName "Muiredhaigh";
+    irishRel:nomName "Muiredhach";
+    rel:childOf <#Ainnrias>.
+
+<#Ainnrias>
+    a foaf:Person;
+    irishRel:genName "Ainnrias";
+    irishRel:nomName "Ainnrias";
+    rel:childOf <#Cormaic>.
+
+<#Cormaic>
+    a foaf:Person;
+    irishRel:genName "Cormaic";
+    irishRel:nomName "Cormac";
+    rel:childOf <#Airbertaigh>.
+
+<#Airbertaigh>
+    a foaf:Person;
+    irishRel:genName "Airbertaigh";
+    irishRel:nomName "Airbertach";
+    rel:childOf <#Ferchairdi>.
+
+<#Ferchairdi>
+    a foaf:Person;
+    irishRel:genName "Ferchairdi";
+    rel:childOf <#FerchairFhada>.
+    #Black suggests that this is an attempt by the scribe to correct "Ferchair"
+    #to "Feradaigh". - EPT
+
+<#FerchairFhada>
+    a foaf:Person;
+    irishRel:genName "Ferchair Fhada";
+    irishRel:nomName "Ferchar Fada";
+    rel:childOf <#FeradhaighFinn>;
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#FercairFada>.
+
+<#FeradhaighFinn>
+    a foaf:Person;
+    irishRel:genName "Feradhaigh Finn";
+    irishRel:nomName "Feradach Finn";
+    owl:sameAs <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_2.trig#Fearadhaigh>.
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_7.trig
@@ -95,8 +95,9 @@
     a foaf:Person;
     irishRel:genName "Ferchairdi";
     rel:childOf <#FerchairFhada>.
-    #Black suggests that this is an attempt by the scribe to correct "Ferchair"
-    #to "Feradaigh". - EPT
+    << <#Ferchairdi>
+          rdfs:comment "Black suggests that this is an attempt by the scribe to correct 'Ferchair' to 'Feradaigh'." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#FerchairFhada>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
@@ -15,14 +15,14 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Genelach Cloinni Maeil Anfaigh"@sga;
+    dcterms:title "Genelach Cloinni Mhaeil Anfaigh"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2008.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2008.html> .
 
-<#Eogan>
+<#Eoghan>
     a foaf:Person;
-    irishRel:nomName "Eogan";
+    irishRel:nomName "Eoghan";
     rel:childOf <#DomnaillDhuib>.
 
 <#DomnaillDhuib>
@@ -35,6 +35,8 @@
     a foaf:Person;
     irishRel:genName "Ailin";
     irishRel:nomName "Ailin".
+    #The lack of rel:childOf is intentional. There is no "mhic" or equivalent
+    #in this MS. - EPT
 
 <#MaelAnfhaid>
     a foaf:Person;
@@ -51,11 +53,11 @@
     a foaf:Person;
     irishRel:genName "Gilla Padraig";
     irishRel:nomName "Gilla Padraig";
-    rel:childOf <#GillaMartain>.
+    rel:childOf <#GillaMhartain>.
 
-<#GillaMartain>
+<#GillaMhartain>
     a foaf:Person;
-    irishRel:genName "Gilla Martain";
+    irishRel:genName "Gilla Mhartain";
     irishRel:nomName "Gilla Martain";
     rel:childOf <#Pfoil>.
 
@@ -76,9 +78,19 @@
     irishRel:genName "Gilla Anfoid";
     irishRel:nomName "Gilla Anfoid";
     rel:childOf <#GillaAnfoid>;
-    rdfs:comment "a quo Clann Gilla Camsronic 7 Clann M[aol Anfaigh] o fuilid [...]";
-    rel:ancestorOf <#Ailin>.
-    #Both this name and this note are difficult to read in the MS. - EPT
+    rdfs:comment "a quo Clann Gilla Camsronich 7 Clann M[aol Anfaigh] o fuilid [...]";
+    rel:ancestorOf <#Ailin>;
+    irishRel:ancestorOfGroup <#ClannGillaCamsronich>, <#ClannMaolAnfaigh>.
+    #Both this name and this note are difficult to read in the MS. Black identifies
+    #CLann Maol Anfaigh as the MacGillonies. - EPT
+
+<#ClannGillaCamsronich>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Gilla Camsronich".
+
+<#ClannMaolAnfaigh>
+    a irishRel:populationGroup;
+    irishRel:populationGroupName "Clann Maol Anfaigh".
 
 <#Eoin>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
@@ -35,9 +35,9 @@
     a foaf:Person;
     irishRel:genName "Ailin";
     irishRel:nomName "Ailin".
-    #The lack of rel:childOf is intentional. There is no "mhic" or equivalent
-    #in this MS. Black suggests that the connection with the pedigree that follows
-    #may be through an unspecified female. - EPT
+    << <#Ailin>
+          rdfs:comment "The lack of rel:childOf is intentional. There is no 'mhic' or equivalent at this point in this MS. Black suggests that the connection with the pedigree that follows may be through an unspecified female." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#MaelAnfhaid>
     a foaf:Person;
@@ -82,8 +82,9 @@
     rdfs:comment "a quo Clann Gilla Camsronich 7 Clann M[aol Anfaigh] o bfuilid genelaigh b'inme i tighib ut";
     rel:ancestorOf <#Ailin>;
     irishRel:ancestorOfGroup <#ClannGillaCamsronich>, <#ClannMaolAnfaigh>.
-    #Both this name and this note are difficult to read in the MS. Black identifies
-    #CLann Maol Anfaigh as the MacGillonies. - EPT
+    << <#GillaAnfoid>
+          rdfs:comment "Both this name and this note are difficult to read in the MS. Black identifies CLann Maol Anfaigh as the MacGillonies." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#ClannGillaCamsronich>
     a irishRel:populationGroup;
@@ -92,8 +93,6 @@
 <#ClannMaolAnfaigh>
     a irishRel:populationGroup;
     irishRel:populationGroupName "Clann Maol Anfaigh".
-
-
 
 <#Eoin>
     a foaf:Person;
@@ -117,7 +116,9 @@
     irishRel:genName "Gelgan";
     rel:childOf <#GillaMartainnMoir>;
     rdfs:comment "i. an Condainnec".
-    #This name is difficult to read in the MS. - EPT
+    << <#Gelgan>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaMartainnMoir>
     a foaf:Person;
@@ -125,24 +126,25 @@
     irishRel:nomName "Gilla Martainn Mor";
     rel:childOf <#GilleChamsroin>;
     rdfs:comment "si".
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaMartainnMoir>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GilChamsroin>
     a foaf:Person;
     irishRel:genName "Gil Chamsroin";
     irishRel:nomName "Gilla Camsroin".
-    #This name is difficult to read in the MS. In particular, line 4 ends "cha"
-    #and, according to Black, the remainder ("msroin") needs to be read from the
-    #left-hand "box", where it also supplied part of the pedigrees title. This
-    #re-use of the same physical text within different contexts is unusual. - EPT
+    << <#GilChamsroin>
+          rdfs:comment "This name is difficult to read in the MS. In particular, line 4 ends 'cha' and, according to Black, the remainder ('msroin') needs to be read from the left-hand 'box', where it also supplied part of the pedigrees title. This re-use of the same physical text within different contexts is unusual." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eogain>
     a foaf:Person;
     irishRel:nomName "Eogain";
     rel:childOf <#GillaFaill>.
-    #Again, the lack of "rel:childOf" on <#GilChamsroin> is intentional. This
-    #name begins another new pedigree. Black asserts that "Eogain" is a
-    #valid ScG. nominative form. - EPT
+    << <#Eogain>
+          rdfs:comment "Again, the lack of 'rel:childOf' on <#GilChamsroin> is intentional. This name begins another new pedigree. Black asserts that 'Eogain' is a valid ScG. nominative form.." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#GillaFaill>
     a foaf:Person;
@@ -155,7 +157,9 @@
     irishRel:genName "Eacada";
     irishRel:nomName "Eochaid";
     rel:childOf <#Gartnaidh>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eacada>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Gartnaidh>
     a foaf:Person;
@@ -168,15 +172,18 @@
     irishRel:genName "Conghgail";
     irishRel:nomName "Congal";
     rel:childOf <#Foailacha>.
-    #This name is difficult to read in the MS. Black suggests "Dighail" (< Dícuill)
-    #as a possible alternative. - EPT
+    << <#Conghgail>
+          rdfs:comment "This name is difficult to read in the MS. Black suggests 'Dighail' (< Dícuill) as a possible alternative." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Foailacha>
     a foaf:Person;
     irishRel:genName "Foailacha";
     irishRel:nomName "Faelchad";
     rel:childOf <#Airt>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Foailacha>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Airt>
     a foaf:Person;
@@ -189,27 +196,25 @@
     irishRel:genName "Aengus Mhoir";
     irishRel:nomName "Aengus Mor";
     rel:childOf <#Ena>.
-    #This name is difficult to read in the MS. - EPT
+    << <#AengusMhoir>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Ena>
     a foaf:Person;
     irishRel:genName "Ena";
     irishRel:nomName "Enna";
     rel:childOf <#Cenit>.
-    #This name is difficult to read in the MS. As Black points out, "eifdh" would
-    #be the most faithful transcription, but it bears no resemblance to any known
-    #Gaelic word, let alone a name. "ena" emerges from moderare emendation, "erc"
-    #from more severe emendation. I have opted for the former of these two options. - EPT
+    << <#Ena>
+          rdfs:comment "This name is difficult to read in the MS. As Black points out, 'eifdh' would be the most faithful transcription, but it bears no resemblance to any known Gaelic word, let alone a name. 'ena' emerges from moderate emendation, 'erc' from more severe emendation. I have opted for the former of these two options." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Cenit>
     a foaf:Person;
     irishRel:genName "Cenit";
     irishRel:nomName "Cinaed".
-    #This name is difficult to read in the MS; Black suggests that it could be
-    #read as "Conlaith", making the last two names the Erc and Conlaith from
-    #Kindred 5 (Mackintoshes). Black hypothesises that these last two names
-    #have been deliberately disguised in this MS. He imagines that the Camerons'
-    #origins had previously been traced back to the Mackintoshes. This became politically unhelpful
-    #but without any alternative tradition being developed to take its place.  - EPT
+    << <#Cenit>
+          rdfs:comment "This name is difficult to read in the MS; Black suggests that it could be read as 'Conlaith', making the last two names the Erc and Conlaith from Kindred 5 (Mackintoshes). Black hypothesises that these last two names have been deliberately disguised in this MS. He imagines that the Camerons' origins had previously been traced back to the Mackintoshes. This became politically unhelpful but without any alternative tradition being developed to take its place." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
@@ -36,7 +36,8 @@
     irishRel:genName "Ailin";
     irishRel:nomName "Ailin".
     #The lack of rel:childOf is intentional. There is no "mhic" or equivalent
-    #in this MS. - EPT
+    #in this MS. Black suggests that the connection with the pedigree that follows
+    #may be through an unspecified female. - EPT
 
 <#MaelAnfhaid>
     a foaf:Person;
@@ -78,7 +79,7 @@
     irishRel:genName "Gilla Anfoid";
     irishRel:nomName "Gilla Anfoid";
     rel:childOf <#GillaAnfoid>;
-    rdfs:comment "a quo Clann Gilla Camsronich 7 Clann M[aol Anfaigh] o fuilid [...]";
+    rdfs:comment "a quo Clann Gilla Camsronich 7 Clann M[aol Anfaigh] o bfuilid genelaigh b'inme i tighib ut";
     rel:ancestorOf <#Ailin>;
     irishRel:ancestorOfGroup <#ClannGillaCamsronich>, <#ClannMaolAnfaigh>.
     #Both this name and this note are difficult to read in the MS. Black identifies
@@ -91,6 +92,8 @@
 <#ClannMaolAnfaigh>
     a irishRel:populationGroup;
     irishRel:populationGroupName "Clann Maol Anfaigh".
+
+
 
 <#Eoin>
     a foaf:Person;
@@ -107,65 +110,71 @@
     a foaf:Person;
     irishRel:genName "Gilla Martain Oig";
     irishRel:nomName "Gilla Martain Oig";
-    rel:childOf <#Gilgain>.
+    rel:childOf <#Gelgan>.
 
-<#Gilgain>
+<#Gelgan>
     a foaf:Person;
-    irishRel:genName "Gilgain";
-    rel:childOf <#Martain>.
+    irishRel:genName "Gelgan";
+    rel:childOf <#GillaMartainnMoir>;
+    rdfs:comment "i. an Condainnec".
     #This name is difficult to read in the MS. - EPT
 
-<#Martain>
+<#GillaMartainnMoir>
     a foaf:Person;
-    irishRel:genName "Martain";
-    irishRel:nomName "Martan";
-    rel:childOf <#GillaMartainn>.
-
-<#GillaMartainn>
-    a foaf:Person;
-    irishRel:genName "Gilla Martainn";
-    irishRel:nomName "Gilla Martainn";
+    irishRel:genName "Gilla Martainn Moir";
+    irishRel:nomName "Gilla Martainn Mor";
     rel:childOf <#GilleChamsroin>;
-    rdfs:comment "moirsin".
+    rdfs:comment "si".
     #This name is difficult to read in the MS. - EPT
 
-<#GilleChamsroin>
+<#GilChamsroin>
     a foaf:Person;
-    irishRel:genName "Gille Chamsroin";
+    irishRel:genName "Gil Chamsroin";
     irishRel:nomName "Gilla Camsroin".
-    #This name is difficult to read in the MS. - EPT
+    #This name is difficult to read in the MS. In particular, line 4 ends "cha"
+    #and, according to Black, the remainder ("msroin") needs to be read from the
+    #left-hand "box", where it also supplied part of the pedigrees title. This
+    #re-use of the same physical text within different contexts is unusual. - EPT
 
 <#Eogain>
     a foaf:Person;
     irishRel:nomName "Eogain";
     rel:childOf <#GillaFaill>.
+    #Again, the lack of "rel:childOf" on <#GilChamsroin> is intentional. This
+    #name begins another new pedigree. Black asserts that "Eogain" is a
+    #valid ScG. nominative form. - EPT
 
 <#GillaFaill>
     a foaf:Person;
     irishRel:genName "Gilla Faill";
     irishRel:nomName "Gilla Faill";
-    rel:childOf <#Eacain>.
+    rel:childOf <#Eacada>.
 
-<#Eacain>
+<#Eacada>
     a foaf:Person;
-    irishRel:genName "Eacain";
-    rel:childOf <#Gartnaid>.
+    irishRel:genName "Eacada";
+    irishRel:nomName "Eochaid";
+    rel:childOf <#Gartnaidh>.
     #This name is difficult to read in the MS. - EPT
 
-<#Gartnaid>
+<#Gartnaidh>
     a foaf:Person;
-    irishRel:genName "Gartnaid";
-    irishRel:nomName "Gartnaid";
-    rel:childOf <#Conigail>.
+    irishRel:genName "Gartnaidh";
+    irishRel:nomName "Gartnaidh";
+    rel:childOf <#Conghgail>.
 
-<#Conigail>
+<#Conghgail>
     a foaf:Person;
-    irishRel:genName "Conigail";
+    irishRel:genName "Conghgail";
+    irishRel:nomName "Congal";
     rel:childOf <#Foailacha>.
+    #This name is difficult to read in the MS. Black suggests "Dighail" (< Dícuill)
+    #as a possible alternative. - EPT
 
 <#Foailacha>
     a foaf:Person;
     irishRel:genName "Foailacha";
+    irishRel:nomName "Faelchad";
     rel:childOf <#Airt>.
     #This name is difficult to read in the MS. - EPT
 
@@ -179,23 +188,28 @@
     a foaf:Person;
     irishRel:genName "Aengus Mhoir";
     irishRel:nomName "Aengus Mor";
-    rel:childOf <#Eirc>.
+    rel:childOf <#Ena>.
     #This name is difficult to read in the MS. - EPT
 
-<#Eirc>
+<#Ena>
     a foaf:Person;
-    irishRel:genName "Eirc";
-    irishRel:nomName "Erc";
+    irishRel:genName "Ena";
+    irishRel:nomName "Enna";
     rel:childOf <#Cenit>.
-    #This name is difficult to read in the MS. - EPT
+    #This name is difficult to read in the MS. As Black points out, "eifdh" would
+    #be the most faithful transcription, but it bears no resemblance to any known
+    #Gaelic word, let alone a name. "ena" emerges from moderare emendation, "erc"
+    #from more severe emendation. I have opted for the former of these two options. - EPT
 
 <#Cenit>
     a foaf:Person;
     irishRel:genName "Cenit";
-    irishRel:nomName "Cinaid".
+    irishRel:nomName "Cinaed".
     #This name is difficult to read in the MS; Black suggests that it could be
-    #read as "Conlaith" (if one hypothesises that the scribe has actively tried
-    #to disguise the name), making the last two names the Erc and Conlaith from
-    #Kindred 5. - EPT
+    #read as "Conlaith", making the last two names the Erc and Conlaith from
+    #Kindred 5 (Mackintoshes). Black hypothesises that these last two names
+    #have been deliberately disguised in this MS. He imagines that the Camerons'
+    #origins had previously been traced back to the Mackintoshes. This became politically unhelpful
+    #but without any alternative tradition being developed to take its place.  - EPT
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig
@@ -1,0 +1,189 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_8.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Cloinni Maeil Anfaigh"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2008.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2008.html> .
+
+<#Eogan>
+    a foaf:Person;
+    irishRel:nomName "Eogan";
+    rel:childOf <#DomnaillDhuib>.
+
+<#DomnaillDhuib>
+    a foaf:Person;
+    irishRel:genName "Domnaill Dhuib";
+    irishRel:nomName "Domnall Dub";
+    rel:childOf <#Ailin>.
+
+<#Ailin>
+    a foaf:Person;
+    irishRel:genName "Ailin";
+    irishRel:nomName "Ailin".
+
+<#MaelAnfhaid>
+    a foaf:Person;
+    irishRel:nomName "Mael Anfhaid";
+    rel:childOf <#Foil>.
+
+<#Foil>
+    a foaf:Person;
+    irishRel:genName "Foil";
+    irishRel:nomName "Pol";
+    rel:childOf <#GillaPadraig>.
+
+<#GillaPadraig>
+    a foaf:Person;
+    irishRel:genName "Gilla Padraig";
+    irishRel:nomName "Gilla Padraig";
+    rel:childOf <#GillaMartain>.
+
+<#GillaMartain>
+    a foaf:Person;
+    irishRel:genName "Gilla Martain";
+    irishRel:nomName "Gilla Martain";
+    rel:childOf <#Pfoil>.
+
+<#Pfoil>
+    a foaf:Person;
+    irishRel:genName "Pfoil";
+    irishRel:nomName "Pol";
+    rel:childOf <#MhailAnfaid>.
+
+<#MhailAnfaid>
+    a foaf:Person;
+    irishRel:genName "Mhail Anfaid";
+    irishRel:nomName "Mael Anfaid";
+    rel:childOf <#GillaAnfoid>.
+
+<#GillaAnfoid>
+    a foaf:Person;
+    irishRel:genName "Gilla Anfoid";
+    irishRel:nomName "Gilla Anfoid";
+    rel:childOf <#GillaAnfoid>;
+    rdfs:comment "a quo Clann Gilla Camsronic 7 Clann M[aol Anfaigh] o fuilid [...]";
+    rel:ancestorOf <#Ailin>.
+    #Both this name and this note are difficult to read in the MS. - EPT
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:nomName "Eoin";
+    rel:childOf <#GillaAnfad>.
+
+<#GillaAnfad>
+    a foaf:Person;
+    irishRel:genName "Gilla Anfad";
+    irishRel:nomName "Gilla Anfad";
+    rel:childOf <#GillaMartainOig>.
+
+<#GillaMartainOig>
+    a foaf:Person;
+    irishRel:genName "Gilla Martain Oig";
+    irishRel:nomName "Gilla Martain Oig";
+    rel:childOf <#Gilgain>.
+
+<#Gilgain>
+    a foaf:Person;
+    irishRel:genName "Gilgain";
+    rel:childOf <#Martain>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Martain>
+    a foaf:Person;
+    irishRel:genName "Martain";
+    irishRel:nomName "Martan";
+    rel:childOf <#GillaMartainn>.
+
+<#GillaMartainn>
+    a foaf:Person;
+    irishRel:genName "Gilla Martainn";
+    irishRel:nomName "Gilla Martainn";
+    rel:childOf <#GilleChamsroin>;
+    rdfs:comment "moirsin".
+    #This name is difficult to read in the MS. - EPT
+
+<#GilleChamsroin>
+    a foaf:Person;
+    irishRel:genName "Gille Chamsroin";
+    irishRel:nomName "Gilla Camsroin".
+    #This name is difficult to read in the MS. - EPT
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:nomName "Eogain";
+    rel:childOf <#GillaFaill>.
+
+<#GillaFaill>
+    a foaf:Person;
+    irishRel:genName "Gilla Faill";
+    irishRel:nomName "Gilla Faill";
+    rel:childOf <#Eacain>.
+
+<#Eacain>
+    a foaf:Person;
+    irishRel:genName "Eacain";
+    rel:childOf <#Gartnaid>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Gartnaid>
+    a foaf:Person;
+    irishRel:genName "Gartnaid";
+    irishRel:nomName "Gartnaid";
+    rel:childOf <#Conigail>.
+
+<#Conigail>
+    a foaf:Person;
+    irishRel:genName "Conigail";
+    rel:childOf <#Foailacha>.
+
+<#Foailacha>
+    a foaf:Person;
+    irishRel:genName "Foailacha";
+    rel:childOf <#Airt>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Airt>
+    a foaf:Person;
+    irishRel:genName "Airt";
+    irishRel:nomName "Art";
+    rel:childOf <#AengusMhoir>.
+
+<#AengusMhoir>
+    a foaf:Person;
+    irishRel:genName "Aengus Mhoir";
+    irishRel:nomName "Aengus Mor";
+    rel:childOf <#Eirc>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Eirc>
+    a foaf:Person;
+    irishRel:genName "Eirc";
+    irishRel:nomName "Erc";
+    rel:childOf <#Cenit>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Cenit>
+    a foaf:Person;
+    irishRel:genName "Cenit";
+    irishRel:nomName "Cinaid".
+    #This name is difficult to read in the MS; Black suggests that it could be
+    #read as "Conlaith" (if one hypothesises that the scribe has actively tried
+    #to disguise the name), making the last two names the Erc and Conlaith from
+    #Kindred 5. - EPT
+
+}

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
@@ -15,7 +15,7 @@
 <>
 
     a dctype:Dataset;
-    dcterms:title "Genelach Mhic Eoghain na hOitreac annso"@sga;
+    dcterms:title "Genelach Mhic Eoghain na hOitreach annso"@sga;
     dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2009.html>;
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2009.html> .
@@ -23,47 +23,56 @@
 <#Baltar>
     a foaf:Person;
     irishRel:nomName "Baltar";
-    rel:childOf <#Eoin>.
+    rel:childOf <#Eain>.
 
-<#Eoin>
+<#Eain>
     a foaf:Person;
-    irishRel:genName "Eoin";
-    irishRel:nomName "Eoin";
+    irishRel:genName "Eain";
+    irishRel:nomName "Eain";
     rel:childOf <#Eogain>.
+    #This name is difficult to read in the MS. - EPT
 
 <#Eogain>
     a foaf:Person;
     irishRel:genName "Eogain";
     irishRel:nomName "Eogan";
-    rel:childOf <#GillaEispaig>.
+    rel:childOf <#GillaEpspaig>.
 
-<#GillaEispaig>
+<#GillaEpspaig>
     a foaf:Person;
-    irishRel:genName "Gilla Eispaig";
-    irishRel:nomName "Gilla Eispaig";
-    rel:childOf <#Crisdin>.
+    irishRel:genName "Gilla Epspaig";
+    irishRel:nomName "Gilla Espaig";
+    rel:childOf <#Eagan>.
     #This name is difficult to read in the MS. - EPT
 
-<#Crisdin>
+<#Eagan>
     a foaf:Person;
-    irishRel:genName "Crisdin";
-    rel:childOf _:missing-d5125f70.
-    #This name is difficult to read in the MS. - EPT
+    irishRel:genName "Eagan";
+    irishRel:nomName "Eoghan";
+    rel:childOf <#Donnchaidh>.
+    #This name is difficult to read in the MS. The most natural transcription would
+    #lead to Crisdin but, due to the visual ambiguities and the poor attestation of
+    #this name, and based on comparison with other genealogies, Black hypothesises
+    #"Eagan" (< Eoghan) instead. - EPT
 
-_:missing-d5125f70
+<#Donnchaidh>
     a foaf:Person;
-    rel:childOf <#Saibara>.
-    #This name is illegible in the MS. - EPT
+    irishRel:genName "Donnchaidh";
+    irishRel:nomName "Donnchadh";
+    rel:childOf [
+      a foaf:Person;
+      rel:childOf [
+        a foaf:Person;
+        rel:childOf <#DonnSleibe>
+        ];
+    ].
+    #This name is illegible in the MS when viewed normally, but can be clearly read
+    #through spectral imaging. Black suggests that the name "Donnchaidh" has been
+    #deliberately deleted. - EPT
 
-<#Saibara>
+<#DonnSleibe>
     a foaf:Person;
-    irishRel:genName "Saibara";
-    rel:childOf <#DuinnSleibe>.
-    #This name is difficult to read in the MS. - EPT
-
-<#DuinnSleibe>
-    a foaf:Person;
-    irishRel:genName "Duinn Sleibe";
+    irishRel:genName "Donn Sleibe";
     irishRel:nomName "Donn Sleibe";
     rel:childOf <#AodaAlainn>.
     #This name is difficult to read in the MS. - EPT
@@ -72,7 +81,7 @@ _:missing-d5125f70
     a foaf:Person;
     irishRel:genName "Aoda Alainn";
     irishRel:nomName "Aod Alainn";
-    rdfs:comment "re nabartha an buirrce";
+    rdfs:comment "renabartha an buirrce";
     rel:childOf <#Anradan>.
     #This name is difficult to read in the MS. - EPT
 
@@ -85,8 +94,8 @@ _:missing-d5125f70
 <#Flaitbertac>
     a foaf:Person;
     irishRel:genName "Flaitbertac";
-    irishRel:nomName "Flaithbertach".
+    irishRel:nomName "Flaithbertach";
+    rdfs:seeAlso <https://www.wikidata.org/entity/Q3073239>.
     #This name is difficult to read in the MS. - EPT
-
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
@@ -30,7 +30,9 @@
     irishRel:genName "Eain";
     irishRel:nomName "Eain";
     rel:childOf <#Eogain>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Eain>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eogain>
     a foaf:Person;
@@ -43,17 +45,18 @@
     irishRel:genName "Gilla Epspaig";
     irishRel:nomName "Gilla Espaig";
     rel:childOf <#Eagan>.
-    #This name is difficult to read in the MS. - EPT
+    << <#GillaEpspaig>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Eagan>
     a foaf:Person;
     irishRel:genName "Eagan";
     irishRel:nomName "Eoghan";
     rel:childOf <#Donnchaidh>.
-    #This name is difficult to read in the MS. The most natural transcription would
-    #lead to Crisdin but, due to the visual ambiguities and the poor attestation of
-    #this name, and based on comparison with other genealogies, Black hypothesises
-    #"Eagan" (< Eoghan) instead. - EPT
+    << <#Eagan>
+          rdfs:comment "This name is difficult to read in the MS. The most natural transcription would lead to Crisdin but, due to the visual ambiguities and the poor attestation of this name, and based on comparison with other genealogies, Black hypothesises 'Eagan' (< Eoghan) instead." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Donnchaidh>
     a foaf:Person;
@@ -66,16 +69,18 @@
         rel:childOf <#DonnSleibe>
         ];
     ].
-    #This name is illegible in the MS when viewed normally, but can be clearly read
-    #through spectral imaging. Black suggests that the name "Donnchaidh" has been
-    #deliberately deleted. - EPT
+    << <#Donnchaidh>
+          rdfs:comment "This name is illegible in the MS when viewed normally, but can be clearly read through spectral imaging. Black suggests that the name 'Donnchaidh' has been deliberately deleted." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#DonnSleibe>
     a foaf:Person;
     irishRel:genName "Donn Sleibe";
     irishRel:nomName "Donn Sleibe";
     rel:childOf <#AodaAlainn>.
-    #This name is difficult to read in the MS. - EPT
+    << <#DonnSleibe>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#AodaAlainn>
     a foaf:Person;
@@ -83,19 +88,25 @@
     irishRel:nomName "Aod Alainn";
     rdfs:comment "renabartha an buirrce";
     rel:childOf <#Anradan>.
-    #This name is difficult to read in the MS. - EPT
+    << <#AodaAlainn>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Anradan>
     a foaf:Person;
     irishRel:genName "Anradan";
     rel:childOf <#Flaitbertac>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Anradan>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 <#Flaitbertac>
     a foaf:Person;
     irishRel:genName "Flaitbertac";
     irishRel:nomName "Flaithbertach";
     rdfs:seeAlso <https://www.wikidata.org/entity/Q3073239>.
-    #This name is difficult to read in the MS. - EPT
+    << <#Flaitbertac>
+          rdfs:comment "This name is difficult to read in the MS." >>
+          prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519>.
 
 }

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
@@ -16,9 +16,9 @@
 
     a dctype:Dataset;
     dcterms:title "Genelach Mhic Eoghain na hOitreach annso"@sga;
-    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2009.html>;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2009.html>, <https://www.1467manuscript.co.uk/MacEwen%20for%20web.pdf>;
     dcterms:format "application/trig" ;
-    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2009.html> .
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2009.html>, <https://www.1467manuscript.co.uk/MacEwen%20for%20web.pdf>.
 
 <#Baltar>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
+++ b/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig
@@ -1,0 +1,92 @@
+@base <http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees/kindred_9.trig>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix foaf:  <http://xmlns.com/foaf/0.1/> .
+@prefix rel: <http://purl.org/vocab/relationship/>.
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+
+
+
+<http://example.com/NLS.Adv.72.1.1/Highland_Pedigrees> {
+<>
+
+    a dctype:Dataset;
+    dcterms:title "Genelach Mhic Eoghain na hOitreac annso"@sga;
+    dcterms:isFormatOf <https://www.1467manuscript.co.uk/kindred%2009.html>;
+    dcterms:format "application/trig" ;
+    prov:asDerivedFrom <https://www.1467manuscript.co.uk/kindred%2009.html> .
+
+<#Baltar>
+    a foaf:Person;
+    irishRel:nomName "Baltar";
+    rel:childOf <#Eoin>.
+
+<#Eoin>
+    a foaf:Person;
+    irishRel:genName "Eoin";
+    irishRel:nomName "Eoin";
+    rel:childOf <#Eogain>.
+
+<#Eogain>
+    a foaf:Person;
+    irishRel:genName "Eogain";
+    irishRel:nomName "Eogan";
+    rel:childOf <#GillaEispaig>.
+
+<#GillaEispaig>
+    a foaf:Person;
+    irishRel:genName "Gilla Eispaig";
+    irishRel:nomName "Gilla Eispaig";
+    rel:childOf <#Crisdin>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Crisdin>
+    a foaf:Person;
+    irishRel:genName "Crisdin";
+    rel:childOf _:missing-d5125f70.
+    #This name is difficult to read in the MS. - EPT
+
+_:missing-d5125f70
+    a foaf:Person;
+    rel:childOf <#Saibara>.
+    #This name is illegible in the MS. - EPT
+
+<#Saibara>
+    a foaf:Person;
+    irishRel:genName "Saibara";
+    rel:childOf <#DuinnSleibe>.
+    #This name is difficult to read in the MS. - EPT
+
+<#DuinnSleibe>
+    a foaf:Person;
+    irishRel:genName "Duinn Sleibe";
+    irishRel:nomName "Donn Sleibe";
+    rel:childOf <#AodaAlainn>.
+    #This name is difficult to read in the MS. - EPT
+
+<#AodaAlainn>
+    a foaf:Person;
+    irishRel:genName "Aoda Alainn";
+    irishRel:nomName "Aod Alainn";
+    rdfs:comment "re nabartha an buirrce";
+    rel:childOf <#Anradan>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Anradan>
+    a foaf:Person;
+    irishRel:genName "Anradan";
+    rel:childOf <#Flaitbertac>.
+    #This name is difficult to read in the MS. - EPT
+
+<#Flaitbertac>
+    a foaf:Person;
+    irishRel:genName "Flaitbertac";
+    irishRel:nomName "Flaithbertach".
+    #This name is difficult to read in the MS. - EPT
+
+
+}


### PR DESCRIPTION
Pedigrees of various West Highland clans and noble families from the 1467 MS (NLS Adv. MS 72.1.1, fol. 1), as well as the kings of Scots and the Lords of the Isles. All sources can be found [here](https://www.1467manuscript.co.uk/index.html).