### PR TITLE
Curator comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 from openjdk:11
-COPY apache-jena-3.16.0.tar.gz .
-RUN tar xfvz apache-jena-3.16.0.tar.gz
-ENV JENA_HOME /apache-jena-3.16.0
+COPY apache-jena-3.17.0.tar.gz .
+RUN tar xfvz apache-jena-3.17.0.tar.gz
+ENV JENA_HOME /apache-jena-3.17.0
 ENV IRISH_GEN_HOME /workspace
 ENTRYPOINT ["/workspace/utils/check_file_syntax.sh"]

--- a/Duanaire_Finn/PoemXLIII.trig
+++ b/Duanaire_Finn/PoemXLIII.trig
@@ -197,7 +197,9 @@
     irishRel:nomName "Banb Sionna";
     rel:childOf <#Úain>.
 
-# Is Banb Sionna female? Both these names are female elsewhere. EPT
+<< <#BhainbSionna>
+        rdfs:comment "Is Banb Sionna female? Both these names are female elsewhere" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cruithgheal>
     a foaf:Person;
@@ -470,7 +472,9 @@
     irishRel:genName "Maicníadh";
     irishRel:nomName "Mac Níadh".
 
-# sameAs <#Maicníadh>? EPT
+<< <#Maicníadh-6cd16530>
+        rdfs:comment "sameAs <#Maicníadh>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fionn-cf130d20>
     a foaf:Person;
@@ -602,7 +606,9 @@
       rel:parentOf <#Dáolgus-ef2c8830>, <#Lodharn>
     ].
 
-# NB: Not Finn mac Cumaill. EPT
+<< <#Finn>
+        rdfs:comment "NB: Not Finn mac Cumaill." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cúain>
     a foaf:Person;
@@ -696,7 +702,9 @@
       rel:childOf <#Trénmóir>
     ].
 
-# Or, rel:siblingOf <#Cnucha> ("a siúir")? EPT
+<< <#Taisi>
+        rdfs:comment "Or, rel:siblingOf <#Cnucha> ('a siúir')?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Trénmóir>
     a foaf:Person;
@@ -763,7 +771,9 @@
     irishRel:nomName "Cormac";
     rel:spouseOf <#Teide>.
 
-# Cormac mac Airt? EPT
+<< <#Cormac>
+        rdfs:comment "Cormac mac Airt?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Ailbhe>
     a foaf:Person;
@@ -864,7 +874,9 @@
     irishRel:nomName "Aillinn";
     rel:siblingOf <#Daigre>.
 
-# Murphy has "daughter of Daigre" but the text clearly has "siúr". EPT
+<< <#Aillinn>
+    rdfs:comment "Murphy has 'daughter of Daigre' but the text clearly has 'siúr'." >>
+    prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Daigre>
     a foaf:Person;
@@ -884,7 +896,9 @@
     irishRel:nomName "Trénmór";
     owl:sameAs <#Tréinmóir>.
 
-# This is "Trénmór of the north", while <#Trenmoir-cb3674f0> is "Trénmór from the east". Could they be different people? EPT
+<< <#Trenmoir>
+    rdfs:comment "This is 'Trénmór of the north', while <#Trenmoir-cb3674f0> is 'Trénmór from the east'. Could they be different people?" >>
+    prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Diangus>
     a foaf:Person;

--- a/Duanaire_Finn/PoemXLIV.trig
+++ b/Duanaire_Finn/PoemXLIV.trig
@@ -90,7 +90,10 @@
     rel:livesWith <#FeargusaFhinnleith>;
     rel:spouseOf <#LughaidhLagha>;
     irishRel:numChild 7.
-# In MS as "Tuirn"; Murphy corrects to "Uirne". EPT
+
+<< <#Uirne-46dd6060>
+        rdfs:comment "In MS as 'Tuirn'; Murphy corrects to 'Uirne'." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Buidhph>
     a foaf:Person;

--- a/Duanaire_Finn/PoemXLV.trig
+++ b/Duanaire_Finn/PoemXLV.trig
@@ -18,7 +18,8 @@
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://celt.ucc.ie/published/G402562/text010.html> .
 
-# I am omitting data from the Patrick-Oisín frame narrative. EPT
+<< <> rdfs:comment "I am omitting data from the Patrick-Oisín frame narrative" >>
+    prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#CnúDeireoil>
     a foaf:Person;

--- a/Duanaire_Finn/PoemXXXVII.trig
+++ b/Duanaire_Finn/PoemXXXVII.trig
@@ -18,7 +18,8 @@
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <https://celt.ucc.ie/published/G402562/text002.html> .
 
-# I am omitting data from the Patrick-Oisín frame narrative. EPT
+<< <> rdfs:comment "I am omitting data from the Patrick-Oisín frame narrative" >>
+    prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fionn>
     a foaf:Person;

--- a/LL/ciarraige.trig
+++ b/LL/ciarraige.trig
@@ -696,9 +696,13 @@
         irishRel:nomName "Oengus";
         rel:childOf <#DuibDaChrích-999cfb3e>.
 
-     <#DuibDaChrích-999cfb3e> # which one? there are others - CY
+     <#DuibDaChrích-999cfb3e>
         a foaf:Person;
         owl:sameAs <#DuibDaChrích-700bf86f>.
+
+     << <#DuibDaChrích-999cfb3e>
+        rdfs:comment "which one? there are others" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#MaelCiarain>
         a foaf:Person;
@@ -723,8 +727,12 @@
         irishRel:nomName "Duib Da Lethi";
         rel:childOf <#DuibDaChrích-6f4b9f5e>.
 
-     <#DuibDaChrích-6f4b9f5e> # which one? there are two above which match. - CY
+     <#DuibDaChrích-6f4b9f5e> 
         owl:sameAs <#DuibDaChrích-700bf86f>.
+
+     << <#DuibDaChrích-6f4b9f5e>
+        rdfs:comment "which one? there are two above which match." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#Fiangus>
         a foaf:Person;
@@ -807,11 +815,15 @@
         irishRel:nomName "Fhergusa";
         rel:childOf [ a foaf:Person;].
 
-     <#h-Irc> # sameas <#h-Ér> ? - CY
+     <#h-Irc> 
         a foaf:Person;
         irishRel:numChild 3;
         irishRel:nomName "Erc";
         irishRel:genName "h-Irc".
+
+     << <#h-Irc>
+        rdfs:comment "sameas <#h-Ér> ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#Coel>
         a foaf:Person;
@@ -838,9 +850,10 @@
         a foaf:Person;
         irishRel:genName "Nad Fraich";
         irishRel:nomName "Nad Frach".
-     #are these the same as
-     # http://example.com/LL/genelach_h_cendselaig.trig#Oengusa-4cb1c4cb
-     # or http://example.com/LL/eoganachta_casil.trig#Oenguis-d5a279b1 ? - CY
+
+     << <#NadFraich>
+        rdfs:comment "are these the same as http://example.com/LL/genelach_h_cendselaig.trig#Oengusa-4cb1c4cb or http://example.com/LL/eoganachta_casil.trig#Oenguis-d5a279b1 ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#Cendlachan>
         a foaf:Person;

--- a/LL/ciarraige_luachra.trig
+++ b/LL/ciarraige_luachra.trig
@@ -477,9 +477,9 @@
         rel:childOf <#Echach>;
         foaf:gender "female".
 
-     # A simpler way of reading this would be to take <#Roich> as a woman, in this
-     # version (Fergus mc do Roich ingin Echach = Fegus, son to Ro-ech, daughter of
-     # Eochu). EPT
+<< <#Roich-7825f8b1>
+        rdfs:comment "A simpler way of reading this would be to take <#Roich> as a woman, in this version (Fergus mc do Roich ingin Echach = Fegus, son to Ro-ech, daughter of Eochu)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Echach>
         a foaf:Person;

--- a/LL/clainde_cernaig.trig
+++ b/LL/clainde_cernaig.trig
@@ -78,8 +78,9 @@
         irishRel:nomName "Ailill";
         rel:childOf <#Cummascaig-38499fcd>.
 
-# Could this instead mean "2 sons of Ailill"? See <http://example.com/Laud_Misc_610/CGH/de_genelach_cloinne_cernaig_in_so.trig>
-# EPT
+     << <#Ailella-30ce2ac2>
+        rdfs:comment "Could this instead mean '2 sons of Ailill'? See <http://example.com/Laud_Misc_610/CGH/de_genelach_cloinne_cernaig_in_so.trig>" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Cummascaig-38499fcd>
         a foaf:Person;

--- a/LL/cland_dubthaig.trig
+++ b/LL/cland_dubthaig.trig
@@ -213,8 +213,14 @@
         rel:childOf <#Dúngaile-f89442b0>;
         owl:sameAs <#Cormaic>;
         rdfs:comment ".i. dibad".
-     # According to the first pedigree, <#Cormaic> is not without offspring? EPT
-     # UPDATE: Maybe "dibad" doesn't necessarily mean without children but that the line eventually died out? EPT
+
+     << <#Cormac-507cd690>
+        rdfs:comment "According to the first pedigree, <#Cormaic> is not without offspring?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
+     << <#Cormac-507cd690>
+        rdfs:comment "UPDATE: Maybe 'dibad' doesn't necessarily mean without children but that the line eventually died out?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Cellach-9894940d>
         a foaf:Person;

--- a/LL/clanna_ébir_i_l-leith_chuind.trig
+++ b/LL/clanna_ébir_i_l-leith_chuind.trig
@@ -2365,7 +2365,6 @@
         a irishTitles:Rí;
         irishRel:nomName "Daig";
         foaf:title "[king of Ireland]".
-        #  EPT
 
 << <#Daig>
         rdfs:comment "Who is this?!" >>

--- a/LL/clanna_ébir_i_l-leith_chuind.trig
+++ b/LL/clanna_ébir_i_l-leith_chuind.trig
@@ -894,7 +894,10 @@
         irishRel:genName "Binnig";
         irishRel:nomName "Binnech";
         owl:sameAs <#Indig>.
-       # Really?! EPT
+
+     << <#Binnig>
+        rdfs:comment "Really?!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Leocan>
         a foaf:Person;
@@ -1079,7 +1082,10 @@
         irishRel:nomName "Art";
         rel:childOf <#Eber>;
         irishRel:numChild 1.
-        # Is this <#Artri>? EPT
+
+     << <#Art>
+        rdfs:comment "Is this <#Artri>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Setna>
         a foaf:Person;
@@ -1403,7 +1409,9 @@
         irishRel:genName "Oengusa Beldeirg";
         irishRel:nomName "Oengus Belderg".
 
-        # I cannot work out who this is or how they fit into the genealogy. EPT
+     << <#OengusaBeldeirg>
+        rdfs:comment "I cannot work out who this is or how they fit into the genealogy." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#ILiach>
         a foaf:Person;
@@ -1425,7 +1433,10 @@
      <#Ilich>
         a foaf:Person;
         irishRel:nomName "Ili[...]ch".
-        # Is this the same as <#ILiach> above? See Rawl B502 which has this CY
+
+     << <#Ilich>
+        rdfs:comment "Is this the same as <#ILiach> above? See Rawl B502 which has this" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#Mál>
         a foaf:Person;
@@ -1435,8 +1446,14 @@
      <#RudraigeLett>
         a foaf:Person;
         irishRel:nomName "Rudraige Lett".
-        # Is this <#Rudraige>? What does "lett" mean? EPT
-        # Rawl B502 has Let m. Rudraigi we should probably go back to the MS CY
+
+<< <#RudraigeLett>
+        rdfs:comment "Is this <#Rudraige>? What does 'lett' mean?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
+<< <#RudraigeLett>
+        rdfs:comment "Rawl B502 has Let m. Rudraigi we should probably go back to the MS" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
      <#Fergus-c22ff810>
         a foaf:Person;
@@ -1757,7 +1774,10 @@
         a foaf:Person;
         irishRel:nomName "Feidlimid";
         owl:sameAs <#Feidlimid>.
-        # Can we assume this is the same Feidlimid? EPT
+
+        << <#Feidlimid-59ab3940>
+        rdfs:comment "Can we assume this is the same Feidlimid?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Enna>
         a irishTitles:Rí;
@@ -1920,8 +1940,9 @@
         foaf:title "[king of Ulster]";
         owl:sameAs <#Fergus-c22ff810>.
 
-        # I have tentatively taken this as a mangled form of "Fergus mac Leti". If so, he
-        # is not a son but a grandson of <#Rudraige>. EPT
+        << <#FergusLaeta>
+        rdfs:comment "I have tentatively taken this as a mangled form of 'Fergus mac Leti'. If so, he is not a son but a grandson of <#Rudraige>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Rudraigi>
         a foaf:Person;
@@ -2010,8 +2031,10 @@
         irishRel:nomName "Fiacha Find";
         rdfs:comment "de Dál Fhíatach";
         foaf:title "[king of Ulster]".
-        # Could this be <http://example.com/LL/senchas_dáil_fhiatach.trig#FhiatachFind>,
-        # ancestor of Dál Fiatach? EPT
+
+     << <#FiachaFind>
+        rdfs:comment "Could this be <http://example.com/LL/senchas_dáil_fhiatach.trig#FhiatachFind>, ancestor of Dál Fiatach?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#Muredach>
         a irishTitles:Rí;
@@ -2315,8 +2338,10 @@
         a foaf:Person;
         irishRel:genName "Cairill";
         irishRel:nomName "Cairell".
-        # Is this <http://example.com/LL/rig_ulad.trig#Cairill>, son of Muiredach Muinderg?
-        # This is nowhere stated but it looks credible chonologically. EPT
+
+<< <#Cairill>
+        rdfs:comment "Is this <http://example.com/LL/rig_ulad.trig#Cairill>, son of Muiredach Muinderg? This is nowhere stated but it looks credible chonologically." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
      <#FergusDubdetach-f50ec6b0>
         a irishTitles:Rí;
@@ -2340,15 +2365,19 @@
         a irishTitles:Rí;
         irishRel:nomName "Daig";
         foaf:title "[king of Ireland]".
-        # Who is this?! EPT
+        #  EPT
 
-     <#Muridach>
-        a irishTitles:Rí;
-        irishRel:genName "Muridach";
-        irishRel:nomName "Muiredach";
-        rel:childOf <#Forgo-f79961dc>;
-        owl:sameAs <#MuridachMunderg>;
-        foaf:title "[king of Ireland]".
+<< <#Daig>
+        rdfs:comment "Who is this?!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
+      <#Muridach>
+         a irishTitles:Rí;
+         irishRel:genName "Muridach";
+         irishRel:nomName "Muiredach";
+         rel:childOf <#Forgo-f79961dc>;
+         owl:sameAs <#MuridachMunderg>;
+         foaf:title "[king of Ireland]".
 
      <#Forgo-f79961dc>
         a foaf:Person;

--- a/LL/comuammand_na_n-genelach.trig
+++ b/LL/comuammand_na_n-genelach.trig
@@ -427,7 +427,10 @@
         irishRel:genName "Conaill Chostamail";
         irishRel:nomName "Conall Costamail";
         rdfs:comment "Ba rí dano cóicid Choncobuir in Conall Costomail.".
-        # Does this mean he was king of Ulster? EPT
+
+<< <#ConaillChostamail>
+        rdfs:comment "Does this mean he was king of Ulster?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
     <#Creidne>
         a foaf:Person;
@@ -436,7 +439,10 @@
         foaf:title "banfhennid"@sga;
         rel:childOf <#ConaillChostamail>;
         rel:spouseOf <#ConaillChostamail>.
-        # Does rel:spouseOf cover only marital relations? EPT
+
+        << <#Creidne>
+        rdfs:comment "Does rel:spouseOf cover only marital relations?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
     <#Aife>
         a foaf:Person;

--- a/LL/conaill_gabra.trig
+++ b/LL/conaill_gabra.trig
@@ -449,8 +449,9 @@
     irishRel:genName "Aeda Bennain";
     irishRel:nomName "Aed Bennain".
 
-# This individual seems like a scribal error. He is nowhere in the parralel
-# pedigree in <http://example.com/LL/eoganachta_casil.trig>. EPT
+<< <#AedaBennain-2efbde20>
+        rdfs:comment "This individual seems like a scribal error. He is nowhere in the parralel pedigree in <http://example.com/LL/eoganachta_casil.trig>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cinaeda>
     a foaf:Person;

--- a/LL/corco_bascind.trig
+++ b/LL/corco_bascind.trig
@@ -96,13 +96,16 @@
     irishRel:numChild 5;
     rel:childOf <#Cuirp-fdb5bfa8>.
 
-# NB: the original text states: Cuirp Luigdech mc Ailella Bascain nó
-# Oengusa Corpri
 <#Cuirp-fdb5bfa8>
   a foaf:Person;
   irishRel:genName "Cuirp Luigdech";
   irishRel:nomName "Corp Luigdech";
   rel:childOf <#AilellaBascain>, <#OengusaCorpri>.
+
+<< <#Cuirp-fdb5bfa8>
+            rdfs:comment "NB: the original text states: Cuirp Luigdech mc Ailella Bascain nó Oengusa Corpri" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+            
 
 <#AilellaBascain>
     a foaf:Person;
@@ -375,7 +378,10 @@ _:missing-eefa250f
     a foaf:Person;
     irishRel:genName "Becce";
     irishRel:nomName "Becc".
-# this looks like Decce instead. need to check edition - CY
+
+<< <#Becce>
+            rdfs:comment "this looks like Decce instead. need to check edition" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Lennan>
     a foaf:Person;

--- a/LL/darine_sil_lugdach.trig
+++ b/LL/darine_sil_lugdach.trig
@@ -535,7 +535,6 @@
     irishRel:genName "Meic Con";
     irishRel:nomName "Mac Cu";
     rel:childOf <#MeicRithe-2c68fb9a>.
-    #  ? - CY
 
 << <#MeicCon-0839e26a>
         rdfs:comment "same as <#MeicCon>" >>

--- a/LL/darine_sil_lugdach.trig
+++ b/LL/darine_sil_lugdach.trig
@@ -535,13 +535,20 @@
     irishRel:genName "Meic Con";
     irishRel:nomName "Mac Cu";
     rel:childOf <#MeicRithe-2c68fb9a>.
-    # same as <#MeicCon> ? - CY
+    #  ? - CY
+
+<< <#MeicCon-0839e26a>
+        rdfs:comment "same as <#MeicCon>" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#MeicRithe-2c68fb9a>
     a foaf:Person;
     irishRel:genName "Meic Rithe";
     irishRel:nomName "Mac Rith".
-#same as <#MeicRithe> or <#MacRitheCenfhota> ? - CY
+
+<< <#MeicRithe-2c68fb9a>
+        rdfs:comment "same as <#MeicRithe> or <#MacRitheCenfhota>" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#AedCamderc>
     a foaf:Person;

--- a/LL/de_genelach_dáil_nia_corbb.trig
+++ b/LL/de_genelach_dáil_nia_corbb.trig
@@ -307,7 +307,10 @@
 <#Daire-f5bc6ca9>
     a foaf:Person;
     irishRel:nomName "Daire".
-# sameAs <#DareBarrach> ? -CY
+
+<< <#Daire-f5bc6ca9>
+        rdfs:comment "sameAs <#DareBarrach> ?">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Breoda>
     a foaf:Person;
@@ -347,7 +350,10 @@
 <#NathÍ-e0cf261f>
     a foaf:Person;
     irishRel:nomName "Nath Í".
-# sameAs <#NathÍ-02b1cebd> ? - CY
+
+<< <#NathÍ-e0cf261f>
+        rdfs:comment "sameAs <#NathÍ-02b1cebd>" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Brudióc>
     a foaf:Person;
@@ -528,7 +534,10 @@
     a foaf:Person;
     irishRel:genName "Corpri";
     irishRel:nomName "Corpre".
-# same as <#Corpri>?
+
+<< <#Corpri-e4635ec6>
+        rdfs:comment "same as <#Corpri>">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Brigit>
     a foaf:Person;
@@ -733,9 +742,14 @@
     a foaf:Person;
     irishRel:nomName "Baeth";
     irishRel:nomName "Baeth".
-# same as <#Baeth> ? - CY
-# I don't think so. In Rawl.B.502, this he is descended from Aillil Mór mac Meic
-# Erca, who is for some reason omitted from LL. EPT
+
+<< <#Baeth-a3e4de7a>
+        rdfs:comment "same as <#Baeth> ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Baeth-a3e4de7a>
+        rdfs:comment "I don't think so. In Rawl.B.502, this he is descended from Aillil Mór mac Meic Erca, who is for some reason omitted from LL." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Faelchu>
     a foaf:Person;
@@ -1223,10 +1237,14 @@
     a foaf:Person;
     irishRel:nomName "Fiachrach";
     rel:childOf <#Fheic-8e3c5e70>.
-# same as fiachra.trig#Fiachra ? - CY
-# As in, Mac Firibisigh's tract on Uí Fhiachrach that we worked on initially?
-# Fiachra son of Eochaid Muigmedón (Connacht) and Fiachra son of Fiacc (Leinster)
-# are definitely not the same. Or is fiachra.trig something else? EPT
+
+<< <#Fiachrach>
+        rdfs:comment "same as fiachra.trig#Fiachra ?">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Fiachrach>
+        rdfs:comment "As in, Mac Firibisigh's tract on Uí Fhiachrach that we worked on initially? Fiachra son of Eochaid Muigmedón (Connacht) and Fiachra son of Fiacc (Leinster) are definitely not the same. Or is fiachra.trig something else? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fheic-8e3c5e70>
     a foaf:Person;

--- a/LL/dimittamus_in_terim.trig
+++ b/LL/dimittamus_in_terim.trig
@@ -39,7 +39,10 @@
     rdfs:seeAlso <https://www.wikidata.org/entity/Q1123545>;
     irishRel:nomName "Conaill Cernaig" ;
     irishRel:ancestorOfGroup <#ClannaConaillCernaig>.
-    # same as eli_descirt.trig and laigsi.trig #ConaillCernaig ? - CY
+
+<< <#ConaillCernaig>
+        rdfs:comment "same as eli_descirt.trig and laigsi.trig #ConaillCernaig ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#ClannaConaillCernaig>
     a irishRel:PopulationGroup ;

--- a/LL/dáil_araide.trig
+++ b/LL/dáil_araide.trig
@@ -8,7 +8,7 @@
 @prefix dctype: <http://purl.org/dc/dcmitype/> .
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix irishTitles: <http://example.com/earlyIrishTitles.ttl#>.
-
+@prefix prov: <http://www.w3.org/ns/prov#> .
 
 
 
@@ -278,8 +278,10 @@
     irishRel:nomName "Fiachaid Findamnas";
     owl:sameAs <http://example.com/LL/dail_araide.trig#FhiachachFind>;
     rel:childOf <#IrielGlunmair>.
-# in dail_araide this are two people #FhiachachFind
-# and #Amnais could this be mistranscription? - CY
+
+<< <#FiachachFindamnais>
+        rdfs:comment "in dail_araide this are two people #FhiachachFind and #Amnais could this be mistranscription?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#IrielGlunmair>
     a foaf:Person;

--- a/LL/dáil_caiss.trig
+++ b/LL/dáil_caiss.trig
@@ -210,10 +210,14 @@
     irishRel:nomName "Scandail";
     rel:childOf <#Carthind>.
 
-<#CormacCochinmeth> # there is a ? by the name - CY
+<#CormacCochinmeth>
     a foaf:Person;
     irishRel:nomName "Cormac Cochinmeth";
     rel:childOf <#Carthind>.
+
+<< <#CormacCochinmeth>
+        rdfs:comment "there is a ? by the name" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Sinech>
     a foaf:Person;

--- a/LL/eli_tuascirt.trig
+++ b/LL/eli_tuascirt.trig
@@ -219,7 +219,10 @@
     foaf:title "sui ecnai"@sga, "sage of knowledge"@eng;
     rel:childOf <#Duach>;
     rdfs:comment "Colman mc Duach mc rig Connacht ollam & faid & suí senchasa Gaedel & sui ecnai is é ro thinóil genelaig [gap: illegible/extent: ? letters]".
-    # As a fragment of the genealogies' conception of their own history, this looks super-important. So I've included it in full. I've also had a look at this page in LL and, unfortunately, the foot of the page, where this appears, is ridiculously hard to read. It looks like it briefly caught fire (!). I can't even find the printed text, let alone any further text. EPT
+
+<< <#Colman>
+        rdfs:comment "As a fragment of the genealogies' conception of their own history, this looks super-important. So I've included it in full. I've also had a look at this page in LL and, unfortunately, the foot of the page, where this appears, is ridiculously hard to read. It looks like it briefly caught fire (!). I can't even find the printed text, let alone any further text." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Duach>
     a foaf:Person;

--- a/LL/eoganachta_casil.trig
+++ b/LL/eoganachta_casil.trig
@@ -627,7 +627,10 @@
     a foaf:Person;
     irishRel:genName "Nath Fraich";
     irishRel:nomName "Nad Fraech".
-# sameas <#NathFraich> or <#NathFraich-47cc38b6>? - CY
+
+<< <#NathFraich-17d2ed08>
+        rdfs:comment "sameas <#NathFraich> or <#NathFraich-47cc38b6>" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Assíd>
     a foaf:Person;
@@ -2251,12 +2254,15 @@
     irishRel:genName "Braccain";
     irishRel:nomName "Braccan";
     rel:childOf <#Dedad-5e067523>.
-# unclear if dedad here is the same as dedad above - CY
 
 <#Dedad-5e067523>
     a foaf:Person;
     irishRel:nomName "Dedad";
     rel:childOf <#Degluine>.
+
+<< <#Dedad-5e067523>
+        rdfs:comment "unclear if dedad here is the same as dedad above" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Degluine>
     a foaf:Person;
@@ -2929,18 +2935,24 @@
     a foaf:Person;
     irishRel:nomName "Cilline";
     rel:childOf <#Lethbrathar>.
-
-# Lethbrathar qui & Brocán ? - CY
-
+        
 <#Lethbrathar>
     a foaf:Person;
     irishRel:nomName "Lethbrathar";
     rel:childOf <#Brocán>.
 
+<< <#Lethbrathar>
+        rdfs:comment "Lethbrathar qui & Brocán ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
 <#Brocán>
     a foaf:Person;
     irishRel:nomName "Brocán";
     rel:childOf <#AedaMóir>.
+
+<< <#Brocán>
+        rdfs:comment "Lethbrathar qui & Brocán ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#AedaMóir>
     a foaf:Person;
@@ -3232,10 +3244,14 @@
     irishRel:nomName "Eogan";
     rel:childOf <#Bresail>.
 
-<#Dubthaeh> # this looks dubious - CY
+<#Dubthaeh>
     a foaf:Person;
     irishRel:nomName "Dubthaeh";
     rel:childOf <#Bresail>.
+
+<< <#Dubthaeh>
+        rdfs:comment "this looks dubious" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Trien>
     a foaf:Person;
@@ -3895,10 +3911,14 @@
     irishRel:nomName "Erc";
     rel:childOf <#Fintait>.
 
-<#Fintait> # sameas <#CormaicFintait> ? - CY
+<#Fintait>
     a foaf:Person;
     irishRel:genName "Fintait";
     irishRel:nomName "Fintat".
+
+<< <#Fintait>
+        rdfs:comment "# sameas <#CormaicFintait> ? ">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Torpaith>
     a foaf:Person;

--- a/LL/eoganachta_casil.trig
+++ b/LL/eoganachta_casil.trig
@@ -2391,11 +2391,9 @@
     owl:sameAs <#DaireCerba>;
     rdfs:comment "Sed alii aliter dicunt ut praediximus".
 
-# This is really confusing, particularly when read alongside 'Senchas Síl Ébir'.
-# I would read this as stating that everyone from Dau to Fidgenid are the sons
-# "filios" of Dáre Cerbae. But I am biased from having just read that in Senchas
-# Síl Ebir (although, "ut praediximus"). Note, however, that the Dáre Cerbae in
-# SSE is not the same person as <#DaireCerba> here (different parentage). EPT
+<< <#DareCerbae>
+        rdfs:comment "This is really confusing, particularly when read alongside 'Senchas Síl Ébir'. I would read this as stating that everyone from Dau to Fidgenid are the sons 'filios' of Dáre Cerbae. But I am biased from having just read that in Senchas Síl Ebir (although, 'ut praediximus'). Note, however, that the Dáre Cerbae in SSE is not the same person as <#DaireCerba> here (different parentage)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Faelchu>
     a foaf:Person;

--- a/LL/erand.trig
+++ b/LL/erand.trig
@@ -85,10 +85,14 @@
     irishRel:genName "Imchada";
     irishRel:nomName "Imchad";
     rel:childOf <#FirChorb>.
-#sameas http://example.com/LLdal_corpri_arad.trig#Imchad ? - CY
-# I fear not. There are no other connections to suggest it
-# and I know of no special relationship between the Eraind
-# and the Laigin that would lead us to expect it. EPT
+
+<< <#Imchada>
+        rdfs:comment "sameas http://example.com/LLdal_corpri_arad.trig#Imchad ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Imchada>
+        rdfs:comment "I fear not. There are no other connections to suggest it and I know of no special relationship between the Eraind and the Laigin that would lead us to expect it." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#FirChorb>
     a foaf:Person;

--- a/LL/fer_manach.trig
+++ b/LL/fer_manach.trig
@@ -118,14 +118,10 @@
     a foaf:Person;
     irishRel:nomName "Gilla Crist";
     rel:childOf <#MeicUidir>.
-# There are two possibile ways of interpreting
-# this second pedigree. "Gilla Crist mac Meic Uidir"
-# could be Gilla Crist, son of Éicnig, son of Dalaig,
-# son of Uidir" from the previous pedigree. If so,
-# perhaps it is there as an alternative ancestry for
-# Uidir, as they differ thereafter? Or is Dub Darach
-# the brother of Gilla Crist from the first pedigree i.e.
-# another son of <#Éicnig>? I am assuming the latter EPT
+
+<< <#GillaCrist-c9fb3700>
+        rdfs:comment "There are two possibile ways of interpreting this second pedigree. 'Gilla Crist mac Meic Uidir' could be 'Gilla Crist, son of Éicnig, son of Dalaig, son of Uidir' from the previous pedigree. If so, perhaps it is there as an alternative ancestry for Uidir, as they differ thereafter? Or is Dub Darach the brother of Gilla Crist from the first pedigree i.e. another son of <#Éicnig>? I am assuming the latter" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MeicUidir>
     a foaf:Person;

--- a/LL/flaith_clainde_colgan.trig
+++ b/LL/flaith_clainde_colgan.trig
@@ -28,14 +28,9 @@
     rel:childOf <#Domnaill>;
     irishRel:ancestorOfGroup <#hOengusa>.
 
-# "Mathgamain .h Oengusa m Domnaill...m Oengusa" has been read here as a
-# tautology - the first Oengusa is also the second Oengusa. How do we know that
-# Mathgamain is not descendant/grandson of Oengus mac Domnaill? The same
-# situation prevails for "Mac Tire .h Uallachain m Uallachain...m Uallachain"
-# below. In its parallel pedigree, dal_corpri_arad gives "Mac Tiri m Uallachain
-# ...m Uallachain". It has not particular claim to authority but might this
-# weigh in against interposing a third Uallachan in that pedigree and a second O
-# Oengus here? EPT
+<< <#Mathgamain>
+        rdfs:comment "'Mathgamain .h Oengusa m Domnaill...m Oengusa' has been read here as a tautology - the first Oengusa is also the second Oengusa. How do we know that Mathgamain is not descendant/grandson of Oengus mac Domnaill? The same situation prevails for 'Mac Tire .h Uallachain m Uallachain...m Uallachain' below. In its parallel pedigree, dal_corpri_arad gives 'Mac Tiri m Uallachain ...m Uallachain'. It has not particular claim to authority but might this weigh in against interposing a third Uallachan in that pedigree and a second Oengus here?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#hOengusa>
     a irishRel:PopulationGroup ;

--- a/LL/genelach_clainde_brannduib.trig
+++ b/LL/genelach_clainde_brannduib.trig
@@ -35,9 +35,9 @@
     irishRel:nomName "Colum";
     owl:sameAs <http://example.com/LL/genelach_h_crimthann_áin.trig#Colum>.
 
-# Comarba usually means the heir of a saint (abbot of their monastery). Surely
-# this makes Gilla Ciarain the heir of a saint called Colum. What about <#Colum>,
-# i.e. Colum of Terryglas, who is of the same kin group? EPT.
+<< <#Coluim-4e4c328e>
+        rdfs:comment "Comarba usually means the heir of a saint (abbot of their monastery). Surely this makes Gilla Ciarain the heir of a saint called Colum. What about <#Colum>, i.e. Colum of Terryglas, who is of the same kin group?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#GillaiFhinneain>
     a foaf:Person;
@@ -122,8 +122,9 @@
     irishRel:nomName "Eochu";
     irishRel:genName "Echac".
 
-# Mongán mac Fiachna might be expected as a source for this sort of thing. But
-# I have been unable to identify Mongán mac Echach. EPT
+<< <#Echac>
+        rdfs:comment "Mongán mac Fiachna might be expected as a source for this sort of thing. But I have been unable to identify Mongán mac Echach." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Nibacraebcrínfheda>
     dcterms:title "Ni ba craeb crínfheda"@sga;

--- a/LL/genelach_clainde_duib_da_chrích.trig
+++ b/LL/genelach_clainde_duib_da_chrích.trig
@@ -51,7 +51,10 @@
     irishRel:numChild 4;
     irishRel:nomName "Duib Da Chrichs";
     rel:childOf <#MaelOchtraig-a03330ac>.
-# same as Duib Da Chrich? {p. 1351}
+
+<< <#DuibDaChrichs>
+        rdfs:comment "same as Duib Da Chrich? {p. 1351}" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#MaelOchtraig-a03330ac>
     owl:sameAs <#MaelOchtraig-4b18ec79>.

--- a/LL/genelach_h-úa_lomthuile.trig
+++ b/LL/genelach_h-úa_lomthuile.trig
@@ -27,10 +27,9 @@
     foaf:title "suí"@sga, "sage"@en;
     foaf:title "rígepscop Lagen"@sga, "Archbishop"@en.
 
-# I have moved the foaf:title data from <#Nuadat> to <#Flann> on the basis that
-# "suí" and "epscop" are both nominatives, so probably relate to the first
-# name in the pedigree.
-# This is corroboated by <http://example.com/Rawl_B502/genelach_úa_lomthuile.trig#Flann>. EPT
+<< <#Fland>
+        rdfs:comment "I have moved the foaf:title data from <#Nuadat> to <#Flann> on the basis that 'suí' and 'epscop' are both nominatives, so probably relate to the first name in the pedigree.  This is corroboated by <http://example.com/Rawl_B502/genelach_úa_lomthuile.trig#Flann>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Nuadat>
     a foaf:Person;

--- a/LL/genelach_h_cendselaig.trig
+++ b/LL/genelach_h_cendselaig.trig
@@ -784,8 +784,9 @@
     a foaf:Person ;
     owl:sameAs <#Aeda-1564fb1c>.
 
-# Is it really <#Aeda-1b6d8258> who is being called king, not his son (name +
-# patronymic)? EPT
+<< <#Aeda-1b6d8258>
+        rdfs:comment "Is it really <#Aeda-1b6d8258> who is being called king, not his son (name + patronymic)?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Rian>
     a foaf:Person;

--- a/LL/genelach_h_falgi.trig
+++ b/LL/genelach_h_falgi.trig
@@ -468,8 +468,9 @@
     rel:childOf <#Mugroin>;
     owl:sameAs <http://example.com/LL/genelach_clainde_mugróin.trig#Cinaeda-169322c6>.
 
-#(.i. a quo alius Mugron na frithberte et a quo Colgu sen Clainde
-# Colgan & Mael Carmuin & Mael Sinchil & Mael Finne)
+<< <#Cinaeda>
+        rdfs:comment "(.i. a quo alius Mugron na frithberte et a quo Colgu sen Clainde Colgan & Mael Carmuin & Mael Sinchil & Mael Finne)" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Mugroin>
     a foaf:Person;

--- a/LL/genelach_h_n-enechglais.trig
+++ b/LL/genelach_h_n-enechglais.trig
@@ -292,9 +292,10 @@
     a foaf:Person;
     irishRel:genName "Baithine";
     irishRel:nomName "Baithin";
-    rel:childOf <#Findchada-f381cdcc>.
+    rel:childOf <#Findchada-f381cdcc> .
 
-# Same as http://example.com/Rawl_B502/de_peritia_&_genelogia_úa_n-enechglais.trig#Báethíne-f555e6c0? - CGY
+<< <#Baithine-2a39f688>
+        rdfs:comment "Same as http://example.com/Rawl_B502/de_peritia_&_genelogia_úa_n-enechglais.trig#Báethíne-f555e6c0?"@eng >> prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Findchada-f381cdcc>
     a foaf:Person;

--- a/LL/h_airgialla.trig
+++ b/LL/h_airgialla.trig
@@ -101,8 +101,9 @@
     irishRel:nomName "Mugdorn Dub";
     rdfs:comment "de Ultaib".
 
-# Does "de Ultaib" also apply to <#MennetChruithnech>?
-# "Ron-alt Mennet Chruithnech & Mugdorn Dub de Ultaib". EPT
+<< <#MugdornDub>
+        rdfs:comment "Does 'de Ultaib' also apply to <#MennetChruithnech>? 'Ron-alt Mennet Chruithnech & Mugdorn Dub de Ultaib'." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MaelBresail>
     a foaf:Person;
@@ -312,9 +313,13 @@
     owl:sameAs <http://example.com/LL/fer_manach.trig#CrimthainnLeith>;
     irishRel:numChild 6.
 
-# ? not sure - CY
-# <#Rochad>, surely? He is the ancestor of Uí Chremthainn.
-# The Sordaige just live among them. EPT
+<< <#Crimthand>
+        rdfs:comment "? not sure" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Crimthand>
+        rdfs:comment "<#Rochad>, surely? He is the ancestor of Uí Chremthainn. The Sordaige just live among them." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Eocho>
     a foaf:Person;

--- a/LL/h_ceinselaig.trig
+++ b/LL/h_ceinselaig.trig
@@ -78,10 +78,9 @@
     irishRel:nomName "Cellach";
     rel:descendantOf <#EnnaeCendselaig>.
 
-# While I can't make any sense of "[gap: illegible/extent: ? letters]
-# c-cath & Broen" either, we surely don't need to leave <#Cellaig> and descendants
-# unconnected to the genealogies. Presumably <#Cellaig> is rel:descendantOf <#EnnaeCendselaig>
-# otherwise he wouldn't be here? EPT
+<< <#Cellaig>
+        rdfs:comment "While I can't make any sense of '[gap: illegible/extent: ? letters] c-cath & Broen' either, we surely don't need to leave <#Cellaig> and descendants unconnected to the genealogies. Presumably <#Cellaig> is rel:descendantOf <#EnnaeCendselaig> otherwise he wouldn't be here?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Broen>
     a foaf:Person;
@@ -168,10 +167,14 @@
     irishRel:nomName "Enna Cennselach";
     rel:childOf <#Labrada>;
     owl:sameAs <http://example.com/LL/genelach_h_cendselaig.trig#EnnaGensalach>.
-    
-# sameAs http://example.com/LL/dal_corpri_arad.trig#Chendselaig ? - CY
-# Yup, but I found a more direct mention in that tract, hiding beneath 
-# a weird spelling variant. EPT
+
+<< <#EnnaeCendselaig>
+        rdfs:comment "sameAs http://example.com/LL/dal_corpri_arad.trig#Chendselaig ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#EnnaeCendselaig>
+        rdfs:comment "Yup, but I found a more direct mention in that tract, hiding beneath a weird spelling variant." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Labrada>
     a foaf:Person;

--- a/LL/h_n_echdach.trig
+++ b/LL/h_n_echdach.trig
@@ -140,11 +140,9 @@
     a irishRel:PopulationGroup ;
     irishRel:populationGroupName ".h. Briain" .
 
-# I am tempted to identify this man with Brían Bóruma, as Cennetig
-# is also a Dál Caiss name and Armagh did align itself with Brían.
-# However, Cennetig was Brían's father and I can't find any descendants
-# of Brían called Cennetig, although he did have a nephew called
-# Cennetig via his brother, Dond Cuan (<http://example.com/LL/tairdelbaig.trig#Cennetig>). EPT
+<< <#Briain>
+        rdfs:comment "I am tempted to identify this man with Brían Bóruma, as Cennetig is also a Dál Caiss name and Armagh did align itself with Brían. However, Cennetig was Brían's father and I can't find any descendants of Brían called Cennetig, although he did have a nephew called Cennetig via his brother, Dond Cuan (<http://example.com/LL/tairdelbaig.trig#Cennetig>)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Find>
     a foaf:Person;

--- a/LL/h_n_eirc.trig
+++ b/LL/h_n_eirc.trig
@@ -190,12 +190,15 @@
     irishRel:genName "Eirc";
     irishRel:nomName "Erc";
     owl:sameAs <#Eirc-07e81090>.
-    
-# Which Erc is this? <#Erc> or <#Eirc-6e290430>? EPT (amended  CY)
-# Hmmm...I am not convinced we can know this for certain, although the fact 
-# that <#Erc> is specified in the next pedigree suggests that this is another
-# Erc. EPT
 
+<< <#Eirc-6e290430>
+        rdfs:comment "Which Erc is this? <#Erc> or <#Eirc-6e290430>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+        
+<< <#Eirc-6e290430>
+        rdfs:comment "Hmmm...I am not convinced we can know this for certain, although the fact that <#Erc> is specified in the next pedigree suggests that this is another Erc." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+        
 <#CendFaelad>
     a foaf:Person;
     irishRel:nomName "Cend Faelad";

--- a/LL/h_osráin.trig
+++ b/LL/h_osráin.trig
@@ -65,7 +65,10 @@
     irishRel:nomName "Ossán";
     irishRel:nomName "Osrán";
     rel:childOf <#Saráin>.
-    # Recte Osráin? I've looked at the manuscript and I am pretty sure the second -s- is an -r-. Also, there needs to be an Osrán somewhere for the title to make sense! EPT
+
+<< <#Ossáin>
+        rdfs:comment "Recte Osráin? I've looked at the manuscript and I am pretty sure the second -s- is an -r-. Also, there needs to be an Osrán somewhere for the title to make sense!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Saráin>
     a foaf:Person;
@@ -256,12 +259,9 @@
     irishRel:nomName "Linga";
     rel:childOf <#Mail-b265b280>.
 
-# In Sil_Birn, Daiglinguae is one person but <#Daig>
-# and <#Linga> are presented as separate names here.
-# If <#Daig> and <#Linga> are separate people,
-# then, in each section, Mál has 8 sons, not
-# 7, as per the text on each occasion. I have
-# therefore linked them all together via owl:sameAs. EPT
+<< <#Linga>
+        rdfs:comment "In Sil_Birn, Daiglinguae is one person but <#Daig> and <#Linga> are presented as separate names here. If <#Daig> and <#Linga> are separate people, then, in each section, Mál has 8 sons, not 7, as per the text on each occasion. I have therefore linked them all together via owl:sameAs." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Eidlech>
     a foaf:Person;

--- a/LL/h_raithnen.trig
+++ b/LL/h_raithnen.trig
@@ -814,8 +814,9 @@
     owl:sameAs <#Colmán-7e0615c0>;
     irishRel:numChild 4.
 
-# <#Colmán-7e0615c0> is the most recent Colmán mentioned.
-# But can we assume that he is Colmán Mór? EPT
+<< <#ColmánMór>
+        rdfs:comment "<#Colmán-7e0615c0> is the most recent Colmán mentioned. But can we assume that he is Colmán Mór?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Scandlán>
     a foaf:Person;

--- a/LL/item_h-úi_labrada.trig
+++ b/LL/item_h-úi_labrada.trig
@@ -702,8 +702,7 @@
     a foaf:Person;
     irishRel:nomName "Cruaich";
     owl:sameAs <#Cruaich>.
-
-#  - CY
+        
 <#MoDimmóc>
     a foaf:Person;
     irishRel:nomName "Mo Dimmóc";

--- a/LL/item_h-úi_labrada.trig
+++ b/LL/item_h-úi_labrada.trig
@@ -677,8 +677,9 @@
     irishRel:nomName "Imchad";
     owl:sameAs <http://example.com/LL/genelach_h-úa_n-ochrae.trig#Imchada>.
 
-# this person is seperate from <#Sinchell> above the original source
-# states "Is díb in da Shinchell"
+<< <#Imchada-a3563f4c>
+        rdfs:comment "this person is seperate from <#Sinchell> above the original source states 'Is díb in da Shinchell'" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Sinchell-5307da2c>
     a foaf:Person;
@@ -702,7 +703,7 @@
     irishRel:nomName "Cruaich";
     owl:sameAs <#Cruaich>.
 
-# Is díb mathair Mo Dimmóc Glinni Uissen .i. d'Íb Cummai. ? - CY
+#  - CY
 <#MoDimmóc>
     a foaf:Person;
     irishRel:nomName "Mo Dimmóc";
@@ -712,6 +713,10 @@
       foaf:gender "female";
       rel:descendantOf <#Cormaic-319eaab2>
     ].
+
+<< <#MoDimmóc>
+        rdfs:comment "Is díb mathair Mo Dimmóc Glinni Uissen .i. d'Íb Cummai. ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#MoChua>
     a foaf:Person;

--- a/LL/lagin.trig
+++ b/LL/lagin.trig
@@ -400,11 +400,10 @@
     a foaf:Person;
     irishRel:nomName "Art";
     rel:childOf <#SetnaSithbacc>.
-    # There are five names listed in the quatrain,
-    # 'Ceithri meic la Setna Sithbacc'. Due to his
-    # lack of identifiable offspring, Art seems the
-    # most suspect. Or should this name be combined
-    # with Mes Delmond, which it always precedes? EPT
+
+<< <#Art>
+        rdfs:comment "There are five names listed in the quatrain, 'Ceithri meic la Setna Sithbacc'. Due to his lack of identifiable offspring, Art seems the most suspect. Or should this name be combined with Mes Delmond, which it always precedes? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MisDelmond>
     a foaf:Person;
@@ -1126,9 +1125,10 @@ _:missing-961c9c4b
     irishRel:genName "Corpre Cluchechair";
     irishRel:nomName "Coirpre Cluichechair";
     rel:childOf <#EithniSithbacc>.
-    # Is this <#Carpre-e9186b00>? It is implied that
-    # he is one of the sons of Eithni by Cú Corbb. But
-    # he has a different sobriquet. EPT
+
+<< <#CorpreCluchechair>
+        rdfs:comment "Is this <#Carpre-e9186b00>? It is implied that he is one of the sons of Eithni by Cú Corbb. But he has a different sobriquet." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#EithniSithbacc>
     a foaf:Person;

--- a/LL/laigsi.trig
+++ b/LL/laigsi.trig
@@ -94,8 +94,9 @@
     foaf:nick "cendmar"@sga;
     rel:childOf <#Findchada>.
 
-# Could "cendmar" be a gloss on "buabalchend"
-# ("ox-head"), rather than a separate nickname? EPT
+<< <#Buabalchind>
+        rdfs:comment "Could 'cendmar' be a gloss on 'buabalchend' ('ox-head'), rather than a separate nickname? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Findchada>
     a foaf:Person;
@@ -120,7 +121,9 @@
     foaf:nick "cendbristi"@sga;
     rel:childOf <#DaireDeirg>.
 
-# Again, is "cendbristi" a nickname or a gloss? EPT
+<< <#FiachachUamanchind>
+        rdfs:comment "Again, is 'cendbristi' a nickname or a gloss?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DaireDeirg>
     a foaf:Person;
@@ -212,11 +215,9 @@
     irishRel:nomName "Mescell";
     rel:descendantOf <#Bacain>.
 
-# I am inferring that <#Mescill> is a descendant of
-# <#Bacain> from the phrase "Sil Bacain mc Lugdach
-# Loigsi a quo Sil Mescill". But it is possible that
-# <#Bacain> actually descends from <#Mescill> and is
-# simply the apical figure for Síl Mescill. EPT
+        << <#Mescill>
+        rdfs:comment "I am inferring that <#Mescill> is a descendant of <#Bacain> from the phrase 'Sil Bacain mc Lugdach' <#Bacain> from the phrase 'Sil Bacain mc Lugdach Loigsi a quo Sil Mescill'. But it is possible that <#Bacain> actually descends from <#Mescill> and is simply the apical figure for Síl Mescill. " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cathal>
     a foaf:Person;
@@ -628,8 +629,9 @@
     foaf:knows <#Bairr-4d968e16>, <#Cairthind>;
     rdfs:comment "Epscop Ibar tra ro baiste da mc déc Bairr mc Cairthind".
 
-# Why are we saying that he knows <#Cairthind>, who is of the previous
-# generation? EPT
+<< <#Ibar>
+        rdfs:comment "Why are we saying that he knows <#Cairthind>, who is of the previous generation?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Bairr-4d968e16>
     a foaf:Person;

--- a/LL/loegaire.trig
+++ b/LL/loegaire.trig
@@ -96,7 +96,10 @@
     a foaf:Person ;
     irishRel:nomName "Fiacha Araide" ;
     irishRel:ancestorOfGroup <#DalAraide>.
-    # child of Ferdach Araide? - CY
+
+<< <#FiachaAraide>
+        rdfs:comment "child of Ferdach Araide?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#DalAraide>
     a irishRel:PopulationGroup ;

--- a/LL/lugne.trig
+++ b/LL/lugne.trig
@@ -125,9 +125,7 @@
     irishRel:nomName "Art Chorp";
     owl:sameAs <http://example.com/LL/lugni_connacht.trig#NiadCorp>.
 
-# The best ID I can find for this individual is
-# <http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#AirtChoirp>,
-# which fits with the oft-repeated notion that the Luigne
-# descend from Tadc mac Céin. Could it be that <#AirtChirp> is the 
-# <#NiadCorp> of lugne_connacht.ttl and <#Ithchaire> is <#Idchuir> etc.? EPT
+<< <#AirtChirp>
+        rdfs:comment "The best ID I can find for this individual is <http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#AirtChoirp>, which fits with the oft-repeated notion that the Luigne descend from Tadc mac Céin. Could it be that <#AirtChirp> is the  <#NiadCorp> of lugne_connacht.ttl and <#Ithchaire> is <#Idchuir> etc.?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/LL/n_dési.trig
+++ b/LL/n_dési.trig
@@ -278,7 +278,9 @@
     a foaf:Person;
     irishRel:nomName "Mael Ochtraig".
 
-# owl:sameAs <http://example.com/LL/n_echach.trig#MaelOchtraig>? EPT
+<< <#MaelOchtraig>
+        rdfs:comment "owl:sameAs <http://example.com/LL/n_echach.trig#MaelOchtraig>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Bran>
     a foaf:Person;
@@ -649,9 +651,9 @@
     irishRel:nomName "Ernine";
     rel:childOf <#NadFraich>.
 
-# The text states that <#Ernine> is son of <#NadFraich> but
-# it would make far more sense for them both to be the two
-# sons of <#Aed-9ffc9700>? EPT
+<< <#Ernine>
+        rdfs:comment "The text states that <#Ernine> is son of <#NadFraich> but it would make far more sense for them both to be the two sons of <#Aed-9ffc9700>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#NadFraich>
     a foaf:Person;
@@ -1040,8 +1042,14 @@
     a foaf:Person;
     irishRel:nomName "Fhingin";
     owl:sameAs <#Fingein>.
-    # same as Fingein ? - CY
-    # that seems a safe bet? EPT
+
+<< <#Fhingin>
+        rdfs:comment "same as Fingein ? ">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Fhingin>
+        rdfs:comment "that seems a safe bet?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MaelAthgen>
     a foaf:Person;
@@ -1689,8 +1697,9 @@
     irishRel:nomName "Eochaid";
     owl:sameAs <#Echdach-6414e582>.
 
-# <#Echdach-6414e582> is the most junior Echdach
-# I can find. EPT
+<< <#Echdach-2a9d52cb>
+        rdfs:comment "<#Echdach-6414e582> is the most junior Echdach I can find." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DubDaMuige>
     a foaf:Person;
@@ -1752,7 +1761,9 @@
     rdfs:comment "AEd Toesech" ;
     irishRel:ancestorOfGroup <#hOrci>.
 
-# Who is this?! EPT
+<< <#Duinech>
+        rdfs:comment "Who is this?!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#hOrci>
     a irishRel:PopulationGroup ;
@@ -1928,8 +1939,9 @@
     irishRel:nomName "Aedgaile";
     irishRel:numChild 8.
 
-# The only way to fit this guy in seems to be
-# to take him as a misprint for "Snedgaile"? EPT
+<< <#Aedgaile>
+        rdfs:comment "The only way to fit this guy in seems to be to take him as a misprint for 'Snedgaile'?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Scanlan-68e94df0>
     a foaf:Person;

--- a/LL/n_echach.trig
+++ b/LL/n_echach.trig
@@ -1447,11 +1447,9 @@
     irishRel:nomName "Duibcormaic";
     owl:sameAs <#Cormac-7bffbd20>.
 
-# While a Dubchormac does appear above (<#Aires>), it hardly seems
-# likely that he would appear here. My theory is that <#AedDub>, a son
-# of <#Cormac-7bffbd20>, was originally written but that this has been
-# mangled in copying. For this reason, <#Duibcormaic> has been marked sameAs
-# <#Cormac-7bffbd20>. EPT
+<< <#Duibcormaic>
+        rdfs:comment "While a Dubchormac does appear above (<#Aires>), it hardly seems likely that he would appear here. My theory is that <#AedDub>, a son of <#Cormac-7bffbd20>, was originally written but that this has been mangled in copying. For this reason, <#Duibcormaic> has been marked sameAs <#Cormac-7bffbd20>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#FerEdind>
     a foaf:Person;
@@ -1522,8 +1520,9 @@
     rel:childOf <#MaeliOdra>;
     rdfs:comment "nó".
 
-# What does "nó" mean? Why should the pedigrees be
-# alternatives when they are different? EPT
+<< <#Tomtenaig>
+        rdfs:comment "What does 'nó' mean? Why should the pedigrees be alternatives when they are different?" >> 
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MaeliOdra>
     a foaf:Person;

--- a/LL/na_n_dese_breg.trig
+++ b/LL/na_n_dese_breg.trig
@@ -313,16 +313,19 @@
     irishRel:nomName "Fiachra";
     rel:childOf <#Feidlimthi>;
     owl:sameAs <#FhiachachSuidge>.
-    # See below, under <#Feidlimthi>. EPT
+
+<< <#Fhiachraig>
+        rdfs:comment "See below, under <#Feidlimthi>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Feidlimthi>
     a foaf:Person;
     irishRel:genName "Feidlimthi";
     irishRel:nomName "Feidlimid";
     owl:sameAs <#FeidlimtheRechtada>.
-    # Is this Feidlimid Rechtaid? He is the only other 
-    # Feidlimid in the pedigree but "Fiachra" is not 
-    # attested as his son anywhere else. "Fiachu Suide" is,
-    # however, and he is the apical figure of the Deisi.
-    # Perhaps a scribal error? EPT
+
+<< <#Feidlimthi>
+        rdfs:comment "Is this Feidlimid Rechtaid? He is the only other Feidlimid in the pedigree but 'Fiachra' is not attested as his son anywhere else. 'Fiachu Suide' is, however, and he is the apical figure of the Deisi. Perhaps a scribal error?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
 }

--- a/LL/na_n_desi_muman.trig
+++ b/LL/na_n_desi_muman.trig
@@ -119,9 +119,9 @@
     irishRel:nomName "Cláire";
     rel:childOf <#Cainnig>.
 
-# This raises an interesting question. The name in the corresponding position
-# in the pedigree in n_dési.ttl is "Lasre"/"Lasair". Same genealogical position,
-# different names - are they still the "same" person? What is a person? EPT
+<< <#Cláre>
+        rdfs:comment "This raises an interesting question. The name in the corresponding position in the pedigree in n_dési.ttl is 'Lasre'/'Lasair'. Same genealogical position, different names - are they still the 'same' person? What is a person? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cainnig>
     a foaf:Person;

--- a/LL/rig_alban.trig
+++ b/LL/rig_alban.trig
@@ -235,7 +235,10 @@ _:missing-02dcec05
     irishRel:nomName "Eochu Riata";
     rel:childOf <#Conaire>;
     rdfs:comment "is eside Carpre Rigfhota".
-    # is eside Carpre Rigfhota ? - CY
+
+<< <#EchachRiatai>
+        rdfs:comment "is eside Carpre Rigfhota ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Conaire>
     a foaf:Person;

--- a/LL/rig_ceniuil_conaill.trig
+++ b/LL/rig_ceniuil_conaill.trig
@@ -182,12 +182,8 @@
     a foaf:Person;
     irishRel:genName "Fhlathbertaig";
     irishRel:nomName "Flathbertach".
-# I can see no way of determining which
-# Flathbertach from the previous pedigree 
-# this is without consulting other sources. 
-# It is presumably not the first, 
-# otherwise there would surely just be one
-# pedigree, but there are two others. Can we 
-# it to be the second, because of the lack 
-# of further specification? EPT
+
+<< <#Fhlathbertaig-42b3b5f0>
+        rdfs:comment "I can see no way of determining which Flathbertach from the previous pedigree this is without consulting other sources.  It is presumably not the first,  otherwise there would surely just be one pedigree, but there are two others. Can we it to be the second, because of the lack  of further specification?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/LL/rig_laigsi_genelach_fl.trig
+++ b/LL/rig_laigsi_genelach_fl.trig
@@ -264,8 +264,14 @@
     irishRel:genName "Lugdac Laoigsig";
     irishRel:nomName "Lugaid Laoigsig";
     rel:childOf <#Laoidhsig>.
-    # is this second one dittography? - CY
-    # I think so. No trace of him in laigsi.ttl EPT
+
+<< <#LugdacLaoigsig>
+        rdfs:comment "is this second one dittography?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#LugdacLaoigsig>
+        rdfs:comment "I think so. No trace of him in laigsi.ttl" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Laoidhsig>
     a foaf:Person;

--- a/LL/rig_ulad.trig
+++ b/LL/rig_ulad.trig
@@ -245,7 +245,10 @@
     a foaf:Person;
     irishRel:nomName "Detsin";
     rel:childOf <#Echdach-3adf2040>.
-    # Nominative? EPT
+
+<< <#Detsin>
+        rdfs:comment "Nominative?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Echdach-3adf2040>
     a foaf:Person;

--- a/LL/senchas_dáil_fhiatach.trig
+++ b/LL/senchas_dáil_fhiatach.trig
@@ -457,8 +457,10 @@
 <#Predae>
     a foaf:Person;
     irishRel:nomName "Predae".
-# I don't know the kin-group of these people
-# but maybe it will become apparent. EPT
+
+<< <#Predae>
+        rdfs:comment "I don't know the kin-group of these people but maybe it will become apparent." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fergaile-105b99f2>
     a irishTitle:Rí ;

--- a/LL/senchas_dáil_fhiatach.trig
+++ b/LL/senchas_dáil_fhiatach.trig
@@ -652,11 +652,17 @@
     irishRel:genName "Baetain";
     irishRel:nomName "Baetan";
     rel:childOf <#Echach>.
-# owl:sameAs <http://example.com/LL/dáil_araide.trig#Baetain>?
+
+<< <#Baetain-ae991bf3>
+        rdfs:comment "owl:sameAs <http://example.com/LL/dáil_araide.trig#Baetain>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Echach>
     a foaf:Person;
     irishRel:genName "Echach";
     irishRel:nomName "Eochu".
-# owl:sameAs <http://example.com/LL/dáil_araide.trig#Echach>?
+
+<< <#Echach>
+        rdfs:comment "owl:sameAs <http://example.com/LL/dáil_araide.trig#Echach>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 }

--- a/LL/senchas_síl_ébir.trig
+++ b/LL/senchas_síl_ébir.trig
@@ -386,10 +386,9 @@
     a irishTitles:Rí ;
     irishRel:nomName "Lugaid Duach Dalta Dedad" .
 
-# I suspect some confusion here. It seems likely that this is <#Duach>, so why
-# is "Lugaid" prefixed to his name? Similarly, I can find no Fintat mac Lugdach
-# but <http://example.com/LL/eoganachta_casil.trig#Fintait> (son of Setna?) is
-# a possibility. So whence is Lugaid? EPT
+<< <#LugaidDuachDaltaDedad>
+            rdfs:comment "I suspect some confusion here. It seems likely that this is <#Duach>, so why is 'Lugaid' prefixed to his name? Similarly, I can find no Fintat mac Lugdach but <http://example.com/LL/eoganachta_casil.trig#Fintait> (son of Setna?) is a possibility. So whence is Lugaid?" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Duach>
     a foaf:Person;
@@ -532,8 +531,9 @@
     irishRel:nomName "Eterscél Mór";
     rdfs:comment "i Temraig".
 
-# Other sources have Eterscél Mór as son of <#Iair> but this isn't actually
-# stated here! EPT
+<< <#EterscélMór>
+            rdfs:comment "Other sources have Eterscél Mór as son of <#Iair> but this isn't actually stated here!" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ConaireMór>
     a foaf:Person;
@@ -658,7 +658,11 @@
     rel:worksWith <#Dare>;
     rdfs:comment "i comflaith" ;
     owl:sameAs <#Dergthene>.
-# owlsameAs <http://example.com/LL/eoganachta_casil.trig#Dergthene>? EPT
+
+
+<< <#Dergthene-8ab65268>
+            rdfs:comment "owlsameAs <http://example.com/LL/eoganachta_casil.trig#Dergthene>? " >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Darine>
     a irishTitles:Rí;
@@ -1195,12 +1199,14 @@
     irishRel:numChild 7;
     rdfs:comment "Secht mc Cruith-".
 
+<< <#Cruith->
+            rdfs:comment "owl:sameAs <#CorpreCruthnechan>?" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
 <#EoganachtMaigeGergind>
     a irishRel:PopulationGroup ;
     irishRel:populationGroupName "Eoganacht Maige Gergind" ;
     rdfs:comment "i n-Alpae" .
-
-# owl:sameAs <#CorpreCruthnechan>? EPT
 
 <#Oengus>
     a foaf:Person;

--- a/LL/sil_birn.trig
+++ b/LL/sil_birn.trig
@@ -219,12 +219,10 @@
     rel:childOf <#Eochada>;
     owl:sameAs <http://example.com/LL/h_raithnen.trig#LaignechFáelad>;
     owl:sameAs <http://example.com/LL/rig_ossairge.trig#LagnichFaelad>.
-#   In h_raithnen, Colmán Mór is the son of Bicni, who is the son of
-#   Laignech Faelad. The editor here states that there is a gap in the
-#   pedigree. The main text of the pedigree, in LL, is undamaged and
-#   continues as in h_raithnen. However, a red-lined box is placed to
-#   to the side that seems to contain names. Yet there seems no prima
-#   facie reason to take this as an interpolation into the pedigree. EPT
+
+<< <#LaignigFhaelad>
+        rdfs:comment "In h_raithnen, Colmán Mór is the son of Bicni, who is the son of Laignech Faelad. The editor here states that there is a gap in the pedigree. The main text of the pedigree, in LL, is undamaged and continues as in h_raithnen. However, a red-lined box is placed to to the side that seems to contain names. Yet there seems no prima facie reason to take this as an interpolation into the pedigree. EPT" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Eochada>
     a foaf:Person;
@@ -429,7 +427,10 @@
 <#Domnall-5cd82a90>
     a foaf:Person;
     irishRel:nomName "Domnall".
-# The father of <#GillaiPatric> above is Dondchad, not Domnall. EPT
+
+<< <#Domnall-5cd82a90>
+        rdfs:comment "The father of <#GillaiPatric> above is Dondchad, not Domnall." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#OengusOsfhrithe-d7cadbe0>
     a foaf:Person;

--- a/LL/sil_maeluidir.trig
+++ b/LL/sil_maeluidir.trig
@@ -297,7 +297,9 @@
 <#MaelOchtraig-617ca905>
     owl:sameAs <http://example.com/LL/genelach_clainde_cobthaig.trig#MaelOchtraig>.
 
-# et mc Mael Duin ? - CY
+<< <#MaelOchtraig-617ca905>
+        rdfs:comment "et mc Mael Duin ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Guaire-6e3992d1>
     a foaf:Person;
@@ -406,7 +408,9 @@
 <#Brain-bd54e005>
     a foaf:Person;
     irishRel:nomName "Brain".
-# sameAs <#Brain-11990b77> ? - CY
 
+<< <#Brain-bd54e005>
+        rdfs:comment "sameAs <#Brain-11990b77> ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 }

--- a/LL/síl_daimini.trig
+++ b/LL/síl_daimini.trig
@@ -194,8 +194,11 @@
 <#Ruadrach>
     a foaf:Person;
     irishRel:nomName "Ruadrach";
-    # Ruaidri? EPT
     rel:childOf <#Artrach>.
+
+<< <#Ruadrach>
+        rdfs:comment "Ruaidri?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Artrach>
     a foaf:Person;

--- a/LL/tairdelbaig.trig
+++ b/LL/tairdelbaig.trig
@@ -82,8 +82,10 @@
     irishRel:nomName "Corc";
     rel:childOf <#Anlón>;
     owl:sameAs <http://example.com/LL/rig_tuadmuman.trig#Luirc>.
-    # "Corc" occupies the exact same position here as "Lorc" in
-    # rig_tuadmuman. Can they really be the same? EPT
+
+<< <#Corc>
+        rdfs:comment "'Corc' occupies the exact same position here as 'Lorc' in rig_tuadmuman. Can they really be the same?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Curc>
     irishRel:nomName "Curc";
@@ -688,9 +690,12 @@
     a foaf:Person;
     irishRel:genName "Dunechaid";
     irishRel:nomName "Eochaid";
-    # Is this an alternative name or another son
-    # who might have played this role? EPT
     rel:childOf <#Eochaid>.
+
+<< <#Dunechaid>
+            irishRel:nomName "Eochaid" >>
+            rdfs:comment "Is this an alternative name or another son who might have played this role? EPT" ;
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .            
 
 <#Dunechda>
     irishRel:genName "Dunechda";
@@ -1166,7 +1171,8 @@
     irishRel:genName "Domnaill";
     irishRel:nomName "Domnall";
     owl:sameAs <#Domnaill-ea7b3ea5>.
-    # This is added on the assumption that
-    # <#Domnaill-02f45c6a> is the most recent
-    # Domnall mentioned. EPT
+
+<< <#Domnaill-02f45c6a>
+            rdfs:comment "This is added on the assumption that <#Domnaill-02f45c6a> is the most recent Domnall mentioned." >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/LL/uathni.trig
+++ b/LL/uathni.trig
@@ -29,8 +29,12 @@
 <#Iarlai>
     a foaf:Person;
     irishRel:nomName "Iarlai";
-    # Iarlaithe? EPT
     rel:childOf <#Matudain>.
+
+<< <#Iarlai>
+        irishRel:nomName "Iarlai" >>
+        rdfs:comment "Iarlaithe?" ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Matudain>
     a foaf:Person;

--- a/LLAdd/LLAdd1.trig
+++ b/LLAdd/LLAdd1.trig
@@ -405,8 +405,9 @@
     foaf:title "rí"@sga, "king"@eng;
     owl:sameAs <http://example.com/LL/senchas_síl_ébir.trig#EoganMór>.
 
-# At this point, the statement is made that Caílte is the only one of the Fian
-# to leave descendants. How do we encode this general statement? EPT
+<< <#Caillti>
+        rdfs:comment "At this point, the statement is made that Caílte is the only one of the Fian to leave descendants. How do we encode this general statement?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Caillti>
     a foaf:Person;
@@ -586,7 +587,10 @@
     irishRel:accName "hEdachan";
     owl:sameAs <#Aodh>;
     irishRel:numChild 1.
-# The identification here is not certain but is the best on offer. EPT
+
+<< <#hEdachan>
+        rdfs:comment "The identification here is not certain but is the best on offer." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Oilil>
     a foaf:Person;
@@ -1180,11 +1184,13 @@
     a irishRel:PopulationGroup;
     irishRel:populationGroupName "Na Mained".
 
-# <#NaMaineda> represents multiple people called Maine but, as the text doesn't
-# specify how many Ailill and Medb begat, a separate URI cannot be created for
-# each of them. EPT
-# UPDATE: There wasn't a solution and this was causing confusion on the graph. So
-# <#NaMained> is becoming a population group rather than a compound individual. EPT
+<< <#NaMained>
+        rdfs:comment "<#NaMaineda> represents multiple people called Maine but, as the text doesn't specify how many Ailill and Medb begat, a separate URI cannot be created for each of them." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
+<< <#NaMained>
+        rdfs:comment "UPDATE: There wasn't a solution and this was causing confusion on the graph. So <#NaMained> is becoming a population group rather than a compound individual." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ConallCernach>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/cland_conchuboir_iterum.trig
+++ b/Laud_Misc_610/CGH/cland_conchuboir_iterum.trig
@@ -27,9 +27,9 @@
     owl:sameAs <http://example.com/LL/senchas_dáil_fhiatach.trig#Mongain>;
     owl:sameAs <http://example.com/LL/dimittamus_in_terim.trig#Mongan>.
 
-# The identification of this individual with Mongán is based on the attribution of
-# 'A Fíachnæ ná ráid in gæ', from which the following verse is extracted, to Mongán
-# mac Fiachna in Rawl. B. 502. EPT
+<< <#Mongan>
+        rdfs:comment " The identification of this individual with Mongán is based on the attribution of 'A Fíachnæ ná ráid in gæ', from which the following verse is extracted, to Mongán mac Fiachna in Rawl. B. 502." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#AFíachnæNáRáidInGæ>
     dcterms:title "A Fíachnæ ná ráid in gæ";

--- a/Laud_Misc_610/CGH/cráeb_ceniúil_fergusa_inso.trig
+++ b/Laud_Misc_610/CGH/cráeb_ceniúil_fergusa_inso.trig
@@ -206,7 +206,9 @@
     irishRel:populationGroupName "Húi Emín";
     rdfs:comment "díbad acht bec".
 
-# Does the statement "díbad acht bec" apply just to the last mentioned group (Uí Emín) or to all these groups? EPT
+<< <#HúiEmín>
+        rdfs:comment "Does the statement "díbad acht bec" apply just to the last mentioned group (Uí Emín) or to all these groups?" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DiarmaitMongach>
     a foaf:Person;
@@ -378,12 +380,9 @@
     irishRel:nomName "Conamal";
     owl:sameAs <http://example.com/Rawl_B502/clann_fergusa.trig#Conaill>.
 
-# Neither <#Cuanach> nor <#Conamail> can be found in the pedigrees in Laud Misc 610 thus far, although
-# they can be identified elsewhere. Has some material been lost? The title of the next section
-# ("Cenél Cóelbad corice so. Cenél immorru Áeda asso sís") suggests that the topic has switched to
-# Cenél Cóelbad, to whom <#Cuanach> belongs. However, as the scribe felt the need to note the preceding
-# topic in the next title, we can infer that the section heading for Cenél Cóelbad was also missing in
-# his source. EPT
+<< <#Conamail>
+        rdfs:comment "Neither <#Cuanach> nor <#Conamail> can be found in the pedigrees in Laud Misc 610 thus far, although they can be identified elsewhere. Has some material been lost? The title of the next section ('Cenél Cóelbad corice so. Cenél immorru Áeda asso sís') suggests that the topic has switched to Cenél Cóelbad, to whom <#Cuanach> belongs. However, as the scribe felt the need to note the preceding topic in the next title, we can infer that the section heading for Cenél Cóelbad was also missing in his source." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Robortach>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/cráeb_ceniúil_fergusa_inso.trig
+++ b/Laud_Misc_610/CGH/cráeb_ceniúil_fergusa_inso.trig
@@ -207,7 +207,7 @@
     rdfs:comment "díbad acht bec".
 
 << <#HúiEmín>
-        rdfs:comment "Does the statement "díbad acht bec" apply just to the last mentioned group (Uí Emín) or to all these groups?" >>
+        rdfs:comment "Does the statement 'díbad acht bec' apply just to the last mentioned group (Uí Emín) or to all these groups?" >>
             prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DiarmaitMongach>

--- a/Laud_Misc_610/CGH/cróeb_cheniúil_binnig_inso.trig
+++ b/Laud_Misc_610/CGH/cróeb_cheniúil_binnig_inso.trig
@@ -295,8 +295,9 @@
     irishRel:nomName "Failbe";
     rel:descendantOf <#EochoBinnech>.
 
-# The descent of <#Failbe> from <#EochoBinnech> is implied by his presence in this section;
-# otherwise, it is not clear how he fits in. EPT
+<< <#Failbe>
+        rdfs:comment "The descent of <#Failbe> from <#EochoBinnech> is implied by his presence in this section; otherwise, it is not clear how he fits in." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Nógus>
     a foaf:Person;
@@ -368,7 +369,9 @@
     rel:descendantOf <#EochoBinnech>;
     irishRel:ancestorOfGroup <#hóiChonaill>.
 
-# Again, this is implied by his presence in the section, nothing more. EPT
+<< <#Cathgus>
+        rdfs:comment "Again, this is implied by his presence in the section, nothing more." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cobraid>
     a foaf:Person;
@@ -448,7 +451,9 @@
     irishRel:genName "Colmán";
     rel:descendantOf <#Crimthand>.
 
-# Earlier, both Cland Odrán and Muinter Chúaich are said to descend from <#Crimthand>. But can we infer this as a result? EPT
+<< <#Colmán>
+        rdfs:comment "Earlier, both Cland Odrán and Muinter Chúaich are said to descend from <#Crimthand>. But can we infer this as a result?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fiachan>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/cróebh_choibniusa_ceniúil_feradaig_in_so.trig
+++ b/Laud_Misc_610/CGH/cróebh_choibniusa_ceniúil_feradaig_in_so.trig
@@ -277,10 +277,9 @@
     a irishRel:PopulationGroup;
     irishRel:populationGroupName "Tellach Máilbressail".
 
-# Once again, Laud introduces a pedigree that cannot be attached to anything
-# that has come previously, although the individuals involved can be identified
-# in other manuscripts. Either material has been lost or a lot of knowledge was
-# expected on the part of the reader. EPT
+<< <#Brolchán>
+        rdfs:comment "Once again, Laud introduces a pedigree that cannot be attached to anything that has come previously, although the individuals involved can be identified in other manuscripts. Either material has been lost or a lot of knowledge was expected on the part of the reader." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Brolchán>
     a foaf:Person;
@@ -609,10 +608,9 @@
     irishRel:nomName "Cárthenn";
     irishRel:numChild 6.
 
-# <#Fíachra-48b27e70> is a son of both <#FergusCennfota> and <#Cárthinn>. <#Cárthinn>
-# could be his mother, but they are presented as if they are a male patriarch below. Could <#Cárthinn>
-# be the son of <#FergusCennfota> and <#Fíachra-48b27e70> his granddon? <#Fíachra-48b27e70> is not
-# on the list of the sons of <#Cárthinn> below. A mystery. EPT
+<< <#Cárthinn>
+        rdfs:comment "<#Fíachra-48b27e70> is a son of both <#FergusCennfota> and <#Cárthinn>. <#Cárthinn> could be his mother, but they are presented as if they are a male patriarch below. Could <#Cárthinn> be the son of <#FergusCennfota> and <#Fíachra-48b27e70> his granddon? <#Fíachra-48b27e70> is not on the list of the sons of <#Cárthinn> below. A mystery." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Húanu>
     a foaf:Person;
@@ -721,8 +719,9 @@
     owl:sameAs <#Lugaid>;
     irishRel:numChild 7.
 
-# <#Lugaid> is the only individual with the same name in the pedigree so this is
-# presumably him (via gen. Lugdach). EPT
+<< <#LugachGunn>
+        rdfs:comment "<#Lugaid> is the only individual with the same name in the pedigree so this is presumably him (via gen. Lugdach)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Crónán-fb2a41e0>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/de_causis_quibus_exules_aquilonensium_ad_muminenses_adducti_sunt.trig
+++ b/Laud_Misc_610/CGH/de_causis_quibus_exules_aquilonensium_ad_muminenses_adducti_sunt.trig
@@ -193,9 +193,8 @@
     prov:wasAttributedTo <#Lucrith>;
     owl:sameAs <http://vanhamel.nl/codecs/Conailla_Medb_m%C3%ADchuru>.
 
-# This section is very terse and the connections between characters are not always apparent.
-# It should be reviewed against the IrishGen database and other sources once more material has been added.
-# Also, a translation exists of 'Conailla medb michura' in Études Celtiques 29; this will be
-# consulted when the opportunity permits. EPT
+<< <>
+        rdfs:comment "This section is very terse and the connections between characters are not always apparent. It should be reviewed against the IrishGen database and other sources once more material has been added. Also, a translation exists of 'Conailla medb michura' in Études Celtiques 29; this will be consulted when the opportunity permits." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 }

--- a/Laud_Misc_610/CGH/de_genelach_brigte.trig
+++ b/Laud_Misc_610/CGH/de_genelach_brigte.trig
@@ -76,8 +76,9 @@
     owl:sameAs <http://example.com/Rawl_B502/do_primforslointib_Lagen_inso.trig#Dian>;
     rdfs:comment "Is and condric & Brigit".
 
-# Laud is correct that <#Déin> is a common ancestor of Fintan and Brigit, but one needs to
-# refer to other manuscripts in order to make the connection. EPT
+<< <#Déin>
+        rdfs:comment "Laud is correct that <#Déin> is a common ancestor of Fintan and Brigit, but one needs to refer to other manuscripts in order to make the connection." >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fergus>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/de_quabsis_torchi_corco_ché.trig
+++ b/Laud_Misc_610/CGH/de_quabsis_torchi_corco_ché.trig
@@ -90,7 +90,9 @@
     irishRel:nomName "hUiriu";
     rel:childOf <#Eochath>.
 
-# Cf. LU, ll. 3083-3085. EPT
+<< <#hUiriu>
+        rdfs:comment "Cf. LU, ll. 3083-3085." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Luccreth>
     a foaf:Person;
@@ -98,15 +100,18 @@
     owl:sameAs <http://example.com/Laud_Misc_610/CGH/de_causis_quibus_exules_aquilonensium_ad_muminenses_adducti_sunt.trig#Lucrith>;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q6696417>.
 
-# Meyer reads "utla creth profetauit", which follows the word division in the manuscript. However, this makes no sense. It is more likely
-# that it reads "ut Lucreth profetauit" (as Lucreth prophesied), particularly as Luccreth appears earlier in the Laud text. EPT
+<< <#Luccreth>
+        rdfs:comment "Meyer reads 'utla creth profetauit', which follows the word division in the manuscript. However, this makes no sense. It is more likely that it reads 'ut Lucreth profetauit' (as Lucreth prophesied), particularly as Luccreth appears earlier in the Laud text." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#BamolMídendmidlaige>
     dcterms:title "Ba mol Mídend midlaige";
     prov:wasAttributedTo <#Luccreth>;
     owl:sameAs <https://www.vanhamel.nl/codecs/Ba_mol_Midend_midlaige>.
 
-# This poem has been edited and translated recently (ITS 65). The translation will be consulted and any further data added. EPT
+<< <#BamolMídendmidlaige> 
+        rdfs:comment "This poem has been edited and translated recently (ITS 65). The translation will be consulted and any further data added." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#CíarraigeLóchrae>
     a irishRel:PopulationGroup;

--- a/Laud_Misc_610/CGH/di_raind_etir_maccu_eilella_flanc_bicc.trig
+++ b/Laud_Misc_610/CGH/di_raind_etir_maccu_eilella_flanc_bicc.trig
@@ -84,8 +84,9 @@ _:missing-4c26e030
     foaf:title "druad"@sga, "druid"@eng;
     owl:sameAs <http://example.com/Laud_Misc_610/CGH/do_bunad_imthecht_eoganachta_in_so.trig#MugRuith>.
 
-# The phrase ".i. Síl Moga Roith [in] druad" appears but it is not at all clear what
-# it refers to. This reading is provisional. EPT
+<< <#MogaRoith> 
+        rdfs:comment "The phrase '.i. Síl Moga Roith [in] druad' appears but it is not at all clear what it refers to. This reading is provisional." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Dáre>
     a foaf:Person;
@@ -154,8 +155,9 @@ _:missing-4c26e030
     owl:sameAs <http://example.com/LL/senchas_síl_ébir.trig#EochoMúmo>;
     rdfs:comment "a quo tota plebs Muman".
 
-# In other sources (e.g. LL/senchas_síl_ébir), Eochu Garb (aka Eochu Mumu) is the son
-# of Mafemis. EPT
+<< <#EochoMumu> 
+        rdfs:comment "In other sources (e.g. LL/senchas_síl_ébir), Eochu Garb (aka Eochu Mumu) is the son of Mafemis.">>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MaccArdae>
     a foaf:Person;
@@ -312,8 +314,9 @@ _:missing-4c26e030
     rdfs:comment "aurthach Comgáin airchindich Imleochu Ibair dar cend forthúath";
     owl:sameAs <#Comgán>.
 
-# It is not clear to me which lineage is the "forthúath" to which Comgán swears
-# brotherhood. The Eoganachta or some branch thereof? EPT
+<< <#Comgáin>
+        rdfs:comment "It is not clear to me which lineage is the 'forthúath' to which Comgán swears brotherhood. The Eoganachta or some branch thereof? >>
+    prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#CrimthanOdor>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/di_raind_etir_maccu_eilella_flanc_bicc.trig
+++ b/Laud_Misc_610/CGH/di_raind_etir_maccu_eilella_flanc_bicc.trig
@@ -10,7 +10,6 @@
 @prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
 
-
 <http://example.com/Laud_Misc_610/CGH> {
 <>
 
@@ -315,7 +314,7 @@ _:missing-4c26e030
     owl:sameAs <#Comgán>.
 
 << <#Comgáin>
-        rdfs:comment "It is not clear to me which lineage is the 'forthúath' to which Comgán swears brotherhood. The Eoganachta or some branch thereof? >>
+        rdfs:comment "It is not clear to me which lineage is the 'forthúath' to which Comgán swears brotherhood. The Eoganachta or some branch thereof?" >>
     prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#CrimthanOdor>
@@ -376,8 +375,9 @@ _:missing-4c26e030
     rel:childOf <#Fedlimthi>;
     owl:sameAs <#Crimthan>.
 
-# Identifications uncertain; this Crimthan speaks to the Ciarraige as if he is
-# kind of Cashel but he has a different patrilineage. EPT
+<< <#Crimthan-6bdc50b0>
+        rdfs:comment "Identifications uncertain; this Crimthan speaks to the Ciarraige as if he is kind of Cashel but he has a different patrilineage." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Fedlimthi>
     a foaf:Person;
@@ -426,14 +426,11 @@ _:missing-4c26e030
     irishRel:genName "Néit";
     rdfs:comment "diatá Carnd hUí Néit".
 
-# As "the hill of the *descendants* of Néit", Carn Uí Néit does not seem likely to
-# be associated with Néit himself. However, it is not clear which of his descendants named here
-# it is associated with. The Metrical Dindsenchas (Poem 40) relates this place to a
-# completely different Néit. EPT
+<< <#Néit>
+        rdfs:comment "As 'the hill of the *descendants* of Néit', Carn Uí Néit does not seem likely to be associated with Néit himself. However, it is not clear which of his descendants named here it is associated with. The Metrical Dindsenchas (Poem 40) relates this place to a completely different Néit." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
-# The section ends with a length passage detailing the mutual obligations of various Munster kingdoms and peoples
-# to each other and the priveliges certain groups reserve to themselves. No genealogical material is immediately
-# available, although some new kin groups are mentioned and closer analysis might allow conclusions to be drawn as to
-# their relationship to one another. EPT
-
+<< <>
+        rdfs:comment "The section ends with a length passage detailing the mutual obligations of various Munster kingdoms and peoples to each other and the priveliges certain groups reserve to themselves. No genealogical material is immediately available, although some new kin groups are mentioned and closer analysis might allow conclusions to be drawn as to their relationship to one another." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/Laud_Misc_610/CGH/do_bunad_imthecht_eoganachta_in_so.trig
+++ b/Laud_Misc_610/CGH/do_bunad_imthecht_eoganachta_in_so.trig
@@ -91,7 +91,10 @@
     irishRel:nomName "Míl Espáne";
     rdfs:comment "tánaise";
     foaf:knows <#Ailill>, <#Óengus>, <#Fíacc>.
-# NOT the well-known Míl Espaine!!! EPT
+
+<< <#MílEspáne>
+        rdfs:comment "NOT the well-known Míl Espaine!!!">>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DálCuind>
     a irishRel:PopulationGroup;

--- a/Laud_Misc_610/CGH/do_fhorshlointib_húa_ndechach.trig
+++ b/Laud_Misc_610/CGH/do_fhorshlointib_húa_ndechach.trig
@@ -27,7 +27,9 @@
     irishRel:nomName "Dub Echdach";
     rdfs:comment "Secht n-aithichaicmi in tíri ria tíachtain Duib Echdach".
 
-# Who is this? He sounds important. EPT
+<< <#DuibEchdach>
+        rdfs:comment "Who is this? He sounds important." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Gallraige>
     a irishRel:PopulationGroup;

--- a/Laud_Misc_610/CGH/do_fhorshlointib_ulad_íar_coitchenn.trig
+++ b/Laud_Misc_610/CGH/do_fhorshlointib_ulad_íar_coitchenn.trig
@@ -291,8 +291,8 @@
     owl:sameAs <http://example.com/Rawl_B502/do_forslointib_ulad_iar_coitchiund_in_so.trig#Céin>;
     owl:sameAs <http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#Cian>.
 
-# The chronology here makes no sense. Two women from the same generation cannot be spouses of
-# Tadc mac Céin (Cormac mac Airt's general; so 2nd cent. AD) and Níall Noígiallach (4th/5th cent.
-# AD). EPT
+<< <>
+        rdfs:comment "The chronology here makes no sense. Two women from the same generation cannot be spouses of Tadc mac Céin (Cormac mac Airt's general; so 2nd cent. AD) and Níall Noígiallach (4th/5th cent. AD)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 }

--- a/Laud_Misc_610/CGH/genelach_cloindi_conchubair_chorraig.trig
+++ b/Laud_Misc_610/CGH/genelach_cloindi_conchubair_chorraig.trig
@@ -320,8 +320,9 @@
     rel:childOf <#Echach>;
     owl:sameAs <http://example.com/LL/clainde_conchobuir_corraig.trig#Fiachra-74241963>.
 
-# Should these be owl:sameAs the sons of Colla Uais of the same names (Etc and Fiachra Tort)
-# above? EPT
+<< <#Fíachra-d43882c1>
+        rdfs:comment "Should these be owl:sameAs the sons of Colla Uais of the same names (Etc and Fiachra Tort) above?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Brión>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/senchas_airgíall_in_so.trig
+++ b/Laud_Misc_610/CGH/senchas_airgíall_in_so.trig
@@ -9,6 +9,7 @@
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#> .
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix biro: <http://purl.org/spar/biro/> .
 
 
 <http://example.com/Laud_Misc_610/CGH> {
@@ -170,10 +171,12 @@
     irishRel:nomName "Mennet Cruithnech";
     irishRel:fosterParentOf <#CollaMend>;
     irishRel:ancestorOfGroup <#DálMennet>;
-    owl:sameAs <http://example.com/LL/h_airgialla.trig#MennetChruithnech>.
+    owl:sameAs <http://example.com/LL/h_airgialla.trig#MennetChruithnech>;
+    biro:isReferencedBy <https://lccn.loc.gov/99054974> .        
 
-# Thomas Charles-Edwards (ECR, p.516) takes Mennet to be a woman. As there is no
-# obvious evidence for this here, this is being left unencoded for now. EPT
+<< <#MennetCruithnech>
+        rdfs:comment "Thomas Charles-Edwards (ECR, p.516) takes Mennet to be a woman. As there is no obvious evidence for this here, this is being left unencoded for now." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MugdornDub>
     a foaf:Person;

--- a/Laud_Misc_610/CGH/senchus_dáil_fíatach.trig
+++ b/Laud_Misc_610/CGH/senchus_dáil_fíatach.trig
@@ -82,8 +82,9 @@
     irishRel:nomName "Fergus Do Deri Brega";
     rel:childOf <#Imchada>.
 
-# <#FergusDoDeriBrega> does not appear in the CELT text but does appear
-# in Meyer's edition. EPT
+<< <#FergusDoDeriBrega>
+        rdfs:comment "<#FergusDoDeriBrega> does not appear in the CELT text but does appear in Meyer's edition." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ÓengusFoscriche>
     a foaf:Person;
@@ -100,9 +101,9 @@
     owl:sameAs <http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#FergusDubdetach>;
     owl:sameAs <http://example.com/LL/senchas_dáil_fhiatach.trig#FergusDubdétach>.
 
-# It is not explicitly stated in Laud Misc 610 that <#FergusDubdétach> is a son
-# of <#Imchada> but this is stated elsewhere (e.g. LL) and only 4 of 5 sons are
-# mentioned otherwise. EPT
+<< <#FergusDubdétach>
+        rdfs:comment "It is not explicitly stated in Laud Misc 610 that <#FergusDubdétach> is a son of <#Imchada> but this is stated elsewhere (e.g. LL) and only 4 of 5 sons are mentioned otherwise." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cían>
     a foaf:Person;
@@ -462,8 +463,9 @@
     owl:sameAs <http://example.com/LL/senchas_dáil_fhiatach.trig#ConaillChostodaig>;
     rdfs:comment "ar ba flaith side fon óenchumma. Ba sí a ráth Óchtar Cuillche nó Cholland i nDruimnib Breg. Is inte randsat maic Chairill a n-orba.".
 
-# It is not clear who <#ConaillChostadaig> is. However, the statement "is inte randsat maic Chairill a n-orba" could be taken
-# as implying that he is a son of <#Cairill>. EPT
+<< <#ConaillChostadaig>
+        rdfs:comment "It is not clear who <#ConaillChostadaig> is. However, the statement 'is inte randsat maic Chairill a n-orba' could be taken as implying that he is a son of <#Cairill>." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cablíni>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/14vb1.trig
+++ b/NLS.Adv.72.1.1/14vb1.trig
@@ -71,7 +71,10 @@
     irishRel:genName "Sthainb";
     rel:childOf <#Ceit>;
     owl:sameAs <http://example.com/Rawl_B502/mínigud_senchais_ébir_inso.trig#Sanb>.
-# Ms reading doubtful. EPT
+
+<< <#Sthainb>
+        rdfs:comment "Ms reading doubtful." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Ceit>
     a foaf:Person;

--- a/NLS.Adv.72.1.1/18vb58.trig
+++ b/NLS.Adv.72.1.1/18vb58.trig
@@ -9,6 +9,7 @@
 @prefix irishRel: <http://example.com/earlyIrishRelationship.ttl#> .
 @prefix irishTitle: <http://example.com/earlyIrishTitles.ttl#>.
 @prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix biro: <http://purl.org/spar/biro/> .
 
 <http://example.com/NLS.Adv.72.1.1> {
 <>
@@ -83,5 +84,8 @@
     irishRel:genName "Abratruaid";
     irishRel:nomName "Abratruad".
 
-# There are various individuals in CGH with "Abratruad" as an element in their name. More research is needed to identify who is being referenced here. Indeed, this could be one person called "In file abratruad" ("the poet of the ruddy eyebrows"). EPT
+<< <#Abratruaid>
+        rdfs:comment "There are various individuals in CGH with 'Abratruad' as an element in their name. More research is needed to identify who is being referenced here. Indeed, this could be one person called 'In file abratruad' ('the poet of the ruddy eyebrows')." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> ;
+        biro:references <https://lccn.loc.gov/63026926> .
 }

--- a/Rawl_B502/_92.trig
+++ b/Rawl_B502/_92.trig
@@ -460,7 +460,9 @@
     rel:antagonistOf <#DuachLadra>;
     owl:sameAs <http://example.com/Rawl_B502/mínigud_senchais_ébir_inso.trig#LugaidLáide>.
 
-# The chronology of the conflict encoded above seems highly incongruous and at least one character (Lugaid Laidech) ought already to be dead when it takes place. Perhaps a clumsy textual interpolation? EPT
+<< <#Lugaid-3d810da0>
+        rdfs:comment "The chronology of the conflict encoded above seems highly incongruous and at least one character (Lugaid Laidech) ought already to be dead when it takes place. Perhaps a clumsy textual interpolation?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ÁedRuad>
     a irishTitles:Rí;

--- a/Rawl_B502/_94.trig
+++ b/Rawl_B502/_94.trig
@@ -188,7 +188,9 @@
     owl:sameAs <http://example.com/LL/lagin.trig#MugCorb>;
     owl:sameAs <http://example.com/Rawl_B502/mínigud_senchais_ébir_inso.trig#MugCorp>.
 
-# It hardly seems credible that Mug Corb could be son of Rechtaid Rigderg. Over 70 years separates them. EPT
+<< <#MogCorb>
+        rdfs:comment "It hardly seems credible that Mug Corb could be son of Rechtaid Rigderg. Over 70 years separates them." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#h-Óengusn-Ollam>
     a irishTitles:Rí;
@@ -934,7 +936,9 @@
     rel:childOf <#Lugaid>;
     rel:antagonistOf <#Artt>.
 
-# This individual appears in no other sources that I know of. It seems that Lugaid Mac Con has been duplicated in error. EPT
+<< <#Lugdach-348fd460>
+        rdfs:comment "This individual appears in no other sources that I know of. It seems that Lugaid Mac Con has been duplicated in error." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Lugaid>
     a irishTitles:Rí;

--- a/Rawl_B502/bunad_laigen.trig
+++ b/Rawl_B502/bunad_laigen.trig
@@ -109,8 +109,9 @@
     irishRel:accName "Sedrach" ;
     rel:ancestorOf <#NuaduNecht>.
 
-# Could <#Lugaid-db5d2810> and <#Sedrach> be the same person
-# (= <http://example.com/Rawl_B502/fursunnud_naile.trig#LugaidLuath>)? EPT
+<< <#Sedrach>
+        rdfs:comment "Could <#Lugaid-db5d2810> and <#Sedrach> be the same person (= <http://example.com/Rawl_B502/fursunnud_naile.trig#LugaidLuath>)? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Bressal>
     a foaf:Person;
@@ -327,7 +328,9 @@
     irishRel:nomName "Ogamuin" ;
     rel:ancestorOf <#NuaduNecht>.
 
-# owl:sameAs <http://example.com/Rawl_B502/fursunnud_naile.trig#Móen> ? EPT
+<< <#Ogamuin>
+        rdfs:comment "owl:sameAs <http://example.com/Rawl_B502/fursunnud_naile.trig#Móen> ? ">>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Óengus-902e76c6>
     a foaf:Person ;
@@ -369,7 +372,9 @@
     irishRel:nomName "Ethér" ;
     rel:ancestorOf <#NuaduNecht>.
 
-# owl:sameAs <http://example.com/Rawl_B502/fursunnud_naile.trig#Ethrél> ?
+<< <#Ethér>
+        rdfs:comment "owl:sameAs <http://example.com/Rawl_B502/fursunnud_naile.trig#Ethrél> ?">>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Éremón>
     a foaf:Person ;

--- a/Rawl_B502/clann_enidri.trig
+++ b/Rawl_B502/clann_enidri.trig
@@ -63,5 +63,8 @@
     a foaf:Person;
     irishRel:genName "Dubáin" ;
     irishRel:nomName "Dubán" .
-#    rel:descendantOf <http://example.com/de_úib_ambrit.trig#Feirbb> ? - CY
+
+<< <#Dubáin>
+        rdfs:comment "rel:descendantOf <http://example.com/de_úib_ambrit.trig#Feirbb> ? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 }

--- a/Rawl_B502/clann_garbáin.trig
+++ b/Rawl_B502/clann_garbáin.trig
@@ -55,7 +55,10 @@
 <#Daigre>
     a foaf:Person ;
     irishRel:genName "Daigre" .
-    # which Daigri is this? - CY
+
+<< <#Daigre>
+        rdfs:comment "which Daigri is this?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Énna>
     a foaf:Person ;

--- a/Rawl_B502/de_genelogia_ceníuil_meic_cárthind.trig
+++ b/Rawl_B502/de_genelogia_ceníuil_meic_cárthind.trig
@@ -674,7 +674,10 @@ _:missing-eeffcb0d
     a foaf:Person;
     irishRel:nomName "Forgco";
     rel:childOf <#Énna>.
-    # same as <#Forgco> above? - CY
+
+<< <#Forgco-e1df91e8>
+        rdfs:comment "same as <#Forgco> above?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Colum>
     a foaf:Person;

--- a/Rawl_B502/de_genelogia_dáil_coirpri_arad.trig
+++ b/Rawl_B502/de_genelogia_dáil_coirpri_arad.trig
@@ -80,7 +80,9 @@
     rel:childOf <#ChoinCorp>;
     rel:childOf <#Eithne>.
 
-# owl:sameAs <#CairpreCluichechair> or <http://example.com/Rawl_B502/mínugud_senchusa_laigin_and_so_sís.trig#CoirpreCruaid>? EPT
+        << <#CoirpreDíchmaircc>
+        rdfs:comment "owl:sameAs <#CairpreCluichechair> or <http://example.com/Rawl_B502/mínugud_senchusa_laigin_and_so_sís.trig#CoirpreCruaid>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Laider>
     a foaf:Person;
@@ -167,5 +169,8 @@
     owl:sameAs <#ÓengusaMúisc>;
     foaf:knows <#Cairpre>;
     rdfs:comment "Ní tárlaic iarum Óengus aniar acht do-bert ferann dó lais tiar .i. Tír n-Duais ar ba fili in Cairpre.".
-# rel:givesLandTo EPT
+
+<< <#Óengus>
+        rdfs:comment "rel:givesLandTo" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/Rawl_B502/de_genelogia_dáil_coirpri_arad_retro.trig
+++ b/Rawl_B502/de_genelogia_dáil_coirpri_arad_retro.trig
@@ -208,5 +208,7 @@
     irishTitles:succeededBy <#CairpreCluichechair>;
     rdfs:comment "Do-bert iarum Óengus ferann do mc a ingine & do-breth leth do Chairpriu a óenur fri cethri macco ind arad & do-bert flaithius dó foraib sicut hodie apparet.".
 
-# rel:gaveLandTo (x4)? EPT
+<< <#Oengus>
+        rdfs:comment "rel:gaveLandTo (x4)?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/Rawl_B502/de_genelogia_dáil_messin_corb.trig
+++ b/Rawl_B502/de_genelogia_dáil_messin_corb.trig
@@ -285,7 +285,9 @@
     rdfs:comment "Úi Con Corbb";
     owl:sameAs <http://example.com/LL/dal_corpri_arad.trig#ConCorbb>.
 
-# Is this a descendant of Sétna's or are they named after his ancestor, Cú Corb? EPT
+<< <#ConCorbb>
+        rdfs:comment "Is this a descendant of Sétna's or are they named after his ancestor, Cú Corb?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ConCainnig>
     a foaf:Person;
@@ -723,7 +725,9 @@
     rel:descendantOf <#Dáire-2a4236d0>;
     owl:sameAs <http://example.com/LL/de_genelach_dail_messi_corbb.trig#Techtaire>.
 
-# Is "Techtaire" a name or a job title? EPT
+<< <#Techtaire>
+        rdfs:comment "Is 'Techtaire' a name or a job title?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Conlang-9cc73b10>
     a foaf:Person;

--- a/Rawl_B502/de_peritia_&_genelogia_úa_n-enechglais.trig
+++ b/Rawl_B502/de_peritia_&_genelogia_úa_n-enechglais.trig
@@ -461,7 +461,9 @@
     irishRel:nomName "Maine Mál";
     owl:sameAs <http://example.com/LL/genelach_úa_n-enechglas.trig#ManeMail>.
 
-# owl:sameAs <http://example.com/LL/lagin.trig#ManeMál>? EPT
+<< <#MaineMáil>
+        rdfs:comment "owl:sameAs <http://example.com/LL/lagin.trig#ManeMál>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#CrimthannÁn>
     a foaf:Person;

--- a/Rawl_B502/de_peritia_cenéoil_cairpri_liphechair_incipit.trig
+++ b/Rawl_B502/de_peritia_cenéoil_cairpri_liphechair_incipit.trig
@@ -466,7 +466,11 @@
     irishRel:nomName "Fiachu Tuirtri";
     rel:childOf <#Echach>;
     owl:sameAs <http://example.com/Rawl_B502/genelach_úa_tuirtri.trig#FiachrachTuirtle>.
-    # I am not sure about this sameAs as the genelach_úa_tuirtri.trig has a slightly different line - CY
+
+<< <#FiachuTuirtri>
+        owl:sameAs <http://example.com/Rawl_B502/genelach_úa_tuirtri.trig#FiachrachTuirtle> >>
+        rdfs:comment "I am not sure about this sameAs as the genelach_úa_tuirtri.trig has a slightly different line " ;
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Brion-cb064701>
     a foaf:Person;
@@ -579,7 +583,10 @@
     a foaf:Person ;
     irishRel:genName "Crimthaind" ;
     rel:childOf <#Fiacc-45a83c3e>.
-    # which one <#CrimthannLethan> or <#CrimthannOach> ? - CY
+
+<< <#Crimthaind>
+        rdfs:comment "which one <#CrimthannLethan> or <#CrimthannOach> ? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Labraid-fbe0249f>
     a foaf:Person;

--- a/Rawl_B502/de_peritia_et_genelogia_loíchsi.trig
+++ b/Rawl_B502/de_peritia_et_genelogia_loíchsi.trig
@@ -709,7 +709,9 @@
     irishRel:numChild 12;
     rdfs:comment "Ad-róbart Barr a h-uu & a h-indhuu eter bíu & marbu do epscup Ibar co bráth".
 
-# In neither LL nor Rawl_B502 is it apparent who this is. EPT
+<< <#Bairr-18e16810>
+        rdfs:comment "In neither LL nor Rawl_B502 is it apparent who this is." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cáirthind>
     a foaf:Person;

--- a/Rawl_B502/de_peritia_síl_fiachach_ba_h-aiccid.trig
+++ b/Rawl_B502/de_peritia_síl_fiachach_ba_h-aiccid.trig
@@ -724,7 +724,10 @@
     rel:antagonistOf <#h-UuCeinselaig>;
     rdfs:comment "ro báe h-i r-Ráith Dermaige. Is reme ro mebaid cath Átha Slabai for firu Muman & for h-Uu Ceinselaig. Is é dano ro ort h-Uu Gabla Roírenn. Is é sin cona chlaind do-roíbaid Mo Chuille Dresna iarna sárgud do chath Átha Slabae.".
 
-# Does this all refer to Cellach or to Ronán? EPT
+<< <#Cellach>
+        rdfs:comment "ro báe h-i r-Ráith Dermaige. Is reme ro mebaid cath Átha Slabai for firu Muman & for h-Uu Ceinselaig. Is é dano ro ort h-Uu Gabla Roírenn. Is é sin cona chlaind do-roíbaid Mo Chuille Dresna iarna sárgud do chath Átha Slabae." >>
+        rdfs:comment "Does this all refer to Cellach or to Ronán?" ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#h-UuCeinselaig>
     a irishRel:PopulationGroup;

--- a/Rawl_B502/de_raind_h_érenn.trig
+++ b/Rawl_B502/de_raind_h_érenn.trig
@@ -107,7 +107,10 @@
 <#NadFraích>
     a foaf:Person;
     irishRel:genName "Nad Fraích".
-# there are a bunch of Nad Fraích in LL for Munster. I am not sure which are meant here - CY
+
+<< <#NadFraích>
+        rdfs:comment "there are a bunch of Nad Fraích in LL for Munster. I am not sure which are meant here" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#DímmaDub>
     a foaf:Person;
@@ -115,7 +118,9 @@
     rel:childOf <#Rónáin>;
     foaf:title "rii Dáil Chais"@sga .
 
-# same as http://example.com/LL/eoganachta_casil.ttlDimmaDub ?- CY
+<< <#DímmaDub>
+        rdfs:comment "same as http://example.com/LL/eoganachta_casil.ttlDimmaDub ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Rónáin>
     a irishTitle:Rí;

--- a/Rawl_B502/de_éoganacht_airthir_cliach.trig
+++ b/Rawl_B502/de_éoganacht_airthir_cliach.trig
@@ -94,7 +94,11 @@
     irishRel:nomName "Crimthann" ;
     rel:childOf <#Echach>;
     owl:sameAs <http://example.com/LL/n_echach.trig#Crimthand-4ad6ec86>.
-# Crimthann m. Dercco i n-Daurlus (see http://www.dil.ie/15605) ? - CY
+
+<< <#Crimthann>
+        rdfs:comment "Crimthann m. Dercco i n-Daurlus (see http://www.dil.ie/15605) ? ">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> ;
+        rdfs:seeAlso <http://www.dil.ie/15605> .
 
 <#Cormaic-0a0cede2>
     a foaf:Person;

--- a/Rawl_B502/de_úib_cairpri.trig
+++ b/Rawl_B502/de_úib_cairpri.trig
@@ -60,27 +60,41 @@
 <#Fiachu>
     a foaf:Person ;
     irishRel:nomName "Fiachu" .
-# sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Fiacha>? - CY
+
+<< <#Fiachu>
+        rdfs:comment "sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Fiacha>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Maine>
     a foaf:Person ;
     irishRel:nomName "Maine" .
-# sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Maine? - CY
+
+<< <#Maine>
+        rdfs:comment "sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Maine?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Ailill-2ccbacbd>
     a foaf:Person ;
     irishRel:nomName "Ailill" .
-# sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Ailill? - CY
+
+<< <#Ailill-2ccbacbd>
+        rdfs:comment "sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Ailill?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Fiacho>
     a foaf:Person ;
     irishRel:nomName "Fiacho" .
-# sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Fiacha-4d59c6c7?
+
+<< <#Fiacho>
+        rdfs:comment "sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#Fiacha-4d59c6c7?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#FerDáLiach>
     a foaf:Person ;
     irishRel:nomName "Fer Dá Liach" .
-# sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#FerDáLiach? - CY
 
+<< <#FerDáLiach>
+        rdfs:comment "sameAs http://example.com/Rawl_B502/d_éoganacht_glennamnach.trig#FerDáLiach?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 }

--- a/Rawl_B502/dend_rainn_eter_macco_ailella_flainn_bic.trig
+++ b/Rawl_B502/dend_rainn_eter_macco_ailella_flainn_bic.trig
@@ -125,11 +125,18 @@
     rel:childOf <#MaFemis>;
     rdfs:comment "a quo sunt Éoganachta & Fianna Luigne Úi Dedaid Deocluaid";
     owl:sameAs <http://example.com/LL/senchas_síl_ébir.trig#Loich>.
-    # I am not sure how to interpret "Fianna Luigne Úi Dedaid Deocluaid m. Fiachach Oele" - CY
-    # It is ambiguous. Fiacha Oele could be the father of Dedad Deocluaid or the father of Ma Femis.
-    # And the idea of Fianna descending from someone as if they are a kin-group is interesting. EPT
-    # Update: Having finally located Ma Femis elsewhere in the genealogies, he does not seem to be
-    # the son of Fiacha Oele. EPT
+
+<< <#LóchMár>
+        rdfs:comment "I am not sure how to interpret 'Fianna Luigne Úi Dedaid Deocluaid m. Fiachach Oele'">>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#LóchMár>
+        rdfs:comment "It is ambiguous. Fiacha Oele could be the father of Dedad Deocluaid or the father of Ma Femis. And the idea of Fianna descending from someone as if they are a kin-group is interesting." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
+<< <#LóchMár>
+        rdfs:comment "Update: Having finally located Ma Femis elsewhere in the genealogies, he does not seem to be the son of Fiacha Oele." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MaFemis>
     a foaf:Person ;

--- a/Rawl_B502/do_prímforslointib_lagen_inso.trig
+++ b/Rawl_B502/do_prímforslointib_lagen_inso.trig
@@ -203,7 +203,10 @@
 <#Find>
     a foaf:Person;
     irishRel:nomName "Find".
-# Find mac Cumaill or Find File? EPT
+
+<< <#Find>
+        rdfs:comment "Find mac Cumaill or Find File?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Lóche-84991680>
     a foaf:Person;
@@ -368,7 +371,9 @@
     irishRel:nomName "Coirpre Niad";
     owl:sameAs <http://example.com/Rawl_B502/do_primforslointib_Lagen_inso.trig#CorpriNiad>.
 
-# Lacuna in text? Coirpre Niad hasn't been mentioned previously. EPT
+<< <#CoirpriNiad>
+        rdfs:comment "Lacuna in text? Coirpre Niad hasn't been mentioned previously." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Sétna>
     a foaf:Person;

--- a/Rawl_B502/genelach_benntraige.trig
+++ b/Rawl_B502/genelach_benntraige.trig
@@ -182,7 +182,9 @@
     irishRel:nomName "Amalgaid Réta";
     rdfs:comment "Ó Amalgaid Réta trá ro fodailte secht Laíchsi Lagen .i. ó Licc Réta & lia ríg a cathróe & a n-dúnad & a cáin & a n- dliged.".
 
-# Who even is this?! EPT
+<< <#AmalgaidRéta>
+        rdfs:comment "Who even is this?!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#SílBairr>
     a irishRel:PopulationGroup;

--- a/Rawl_B502/genelach_clainne_cernaich_id_est_úa_nialláin.trig
+++ b/Rawl_B502/genelach_clainne_cernaich_id_est_úa_nialláin.trig
@@ -42,11 +42,17 @@
     irishRel:nomName "Ailill";
     rel:childOf <#Ailella-c0c3be38>.
 
+<< <#Ailella>
+        rdfs:comment "Ailella et Lorccán ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
 <#Lorccán>
     a foaf:Person ;
     irishRel:nomName "Lorccán".
 
-# Ailella et Lorccán ? - CY
+<< <#Lorccán>
+        rdfs:comment "Ailella et Lorccán ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Ailella-c0c3be38>
     a foaf:Person;
@@ -100,11 +106,17 @@
     irishRel:genName "Rónáin";
     rel:childOf <#Suibne-54b04eed>.
 
+<< <#Rónáin>
+        rdfs:comment "Rónáin et Fer Dá Chrích?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
 <#FerDáChrích>
     a foaf:Person ;
     irishRel:genName "Fer Dá Chrích" .
 
-# Rónáin et Fer Dá Chrích? - CY
+<< <#FerDáChrích>
+        rdfs:comment "Rónáin et Fer Dá Chrích?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Suibne-54b04eed>
     a foaf:Person;

--- a/Rawl_B502/genelach_clainne_colgan_liphi.trig
+++ b/Rawl_B502/genelach_clainne_colgan_liphi.trig
@@ -35,10 +35,10 @@
     rel:childOf <#FlaindDáChongal>;
     owl:sameAs <http://example.com/LL/genelach_h_riacain.trig#Oengusa-e104e325>.
 
-# This is the first time an Óengus, son of Fland Dá Chongal, has been mentioned.
-# Does the genealogist mean Óengus son of Mugrón? I think further confusion may have
-# broken out here. EPT
-
+<< <#Óengusa>
+        rdfs:comment "This is the first time an Óengus, son of Fland Dá Chongal, has been mentioned. Does the genealogist mean Óengus son of Mugrón? I think further confusion may have broken out here." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+        
 <#FlaindDáChongal>
     a foaf:Person;
     irishRel:genName "Flaind Dá Chongal";

--- a/Rawl_B502/genelach_clainne_colgcan.trig
+++ b/Rawl_B502/genelach_clainne_colgcan.trig
@@ -344,9 +344,9 @@
     owl:sameAs <http://example.com/LL/genelach_h_mugroin_i_m-maig_liphi.trig#Colgu-cce2ddfe>,
                <http://example.com/LL/flaith_clainde_colgan.trig#Colgan>.
 
-# The is apparently a different Colgu from previously in the section, as he is son
-# of Mugrón mac Óengusa, not Mugrón mac Flaind. I have a feeling the genealogist o
-# or the scribe has got confused, but I will attempt to render the text as he has written it. EPT
+<< <#Colgcan-c4b86860>
+        rdfs:comment "The is apparently a different Colgu from previously in the section, as he is son of Mugrón mac Óengusa, not Mugrón mac Flaind. I have a feeling the genealogist or the scribe has got confused, but I will attempt to render the text as he has written it. " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Mugróin-c4b86861>
     a foaf:Person;

--- a/Rawl_B502/genelach_clainne_colmáin.trig
+++ b/Rawl_B502/genelach_clainne_colmáin.trig
@@ -276,7 +276,10 @@
     a foaf:Person;
     irishRel:genName "na Trí Find Emna";
     rel:childOf <#EchachFeidlich>.
-    # this isn't really a person but I do not want to pull in things from LL - CY
+
+<< <#naTríFindEmna>
+        rdfs:Comment "this isn't really a person but I do not want to pull in things from LL" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#EchachFeidlich>
     a foaf:Person;

--- a/Rawl_B502/genelach_clainne_rotaidi.trig
+++ b/Rawl_B502/genelach_clainne_rotaidi.trig
@@ -96,6 +96,7 @@
     irishRel:genName "Flannchada";
     owl:sameAs <#Flannchada>.
 
-# Or, owl:sameAs <#Flannchada-b33f0200>? I am assuming it is the first Flannchad
-# mentioned, as the pedigree isn't followed any further. EPT
+<< <#Flannchada-f7e0c820>
+        rdfs:comment "Or, owl:sameAs <#Flannchada-b33f0200>? I am assuming it is the first Flannchad mentioned, as the pedigree isn't followed any further." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 }

--- a/Rawl_B502/genelach_dáil_birn_.i._osraige.trig
+++ b/Rawl_B502/genelach_dáil_birn_.i._osraige.trig
@@ -118,7 +118,10 @@
     irishRel:genName "Eochada";
     rel:childOf <#Imchada>;
     owl:sameAs <http://example.com/LL/sil_birn.trig#Eochada>.
-    # Eochaid? EPT
+
+<< <#Eochada>
+        rdfs:comment "Eochaid?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Imchada>
     a foaf:Person;

--- a/Rawl_B502/genelach_síl_daimíni.trig
+++ b/Rawl_B502/genelach_síl_daimíni.trig
@@ -24,7 +24,11 @@
     irishRel:populationGroupName "Síl Daimíni";
     rdfs:comment "h-i Tír Úa n-Geintich & do-róebdatar Úi Geintich nisi pauci .i. Úi Chuirre & Úi Gobbáin";
     owl:sameAs <http://example.com/LL/cland_shechnasaig.trig#SílDamíni>.
-# I don't know how to translate this at present ("nisi pauci"?). EPT
+
+<< <#SílDaimíni>
+        rdfs:comment "h-i Tír Úa n-Geintich & do-róebdatar Úi Geintich nisi pauci .i. Úi Chuirre & Úi Gobbáin" >>
+        rdfs:comment "I don't know how to translate this at present ('nisi pauci'?)." ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Augra>
     a foaf:Person;

--- a/Rawl_B502/genelach_úa_failge.trig
+++ b/Rawl_B502/genelach_úa_failge.trig
@@ -536,7 +536,9 @@
     owl:sameAs <http://example.com/LL/genelach_h_falgi.trig#Bruidgi-ba3600a7>;
     owl:sameAs <#Bruidge>.
 
-# Or owl:sameAs <#Bruidge-b1409c40>? EPT
+<< <#Bruidgi>
+        rdfs:comment "Or owl:sameAs <#Bruidge-b1409c40>? ">>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cathail-dc9f5fbc>
     a irishTitle:Rí;

--- a/Rawl_B502/genelach_úa_lomthuile.trig
+++ b/Rawl_B502/genelach_úa_lomthuile.trig
@@ -28,8 +28,9 @@
     rel:childOf <#Nuadat>;
     owl:sameAs <http://example.com/LL/genelach_h-úa_lomthuile.trig#Fland>.
 
-# This individual really sounds like they should appear in the Annals at some
-# point but I can find no record of them! EPT
+<< <#Flann>
+        rdfs:comment "This individual really sounds like they should appear in the Annals at some point but I can find no record of them!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Nuadat>
     a foaf:Person;

--- a/Rawl_B502/genelach_úa_m-bairrche.trig
+++ b/Rawl_B502/genelach_úa_m-bairrche.trig
@@ -460,9 +460,10 @@
     dcterms:title "Longais maro Muiredach"@sga;
     owl:sameAs <http://www.vanhamel.nl/codecs/Nidu_d%C3%ADr_dermait>;
     prov:wasAttributedTo <#Laidcenn>.
-#Here, a stanza from a longer poem (already given in extenso) is being cited.
-#Can we still say owl:sameAs? Or can we make a new ontology to denote an extract
-#from a larger work? EPT
+
+<< <#LongaismaroMuiredach>
+        rdfs:comment "Here, a stanza from a longer poem (already given in extenso) is being cited. Can we still say owl:sameAs? Or can we make a new ontology to denote an extract from a larger work?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Laidcenn>
     a foaf:Person;
@@ -473,9 +474,11 @@
     a irishRel:PopulationGroup ;
     irishRel:populationGroupName "Cenél Cróchnae";
     rdfs:comment "Cenél Cróchnae in cethramad prím-aiccme Úa m-Bairrchi. Is fri Ú Breccáin a tóebud." .
-#I'm not sure about this. "Is fri Ú Breccáin a tóebud" seems to mean literally
-# "They are near to Uí Breccáin", that is, they are closely related to Uí Breccáin.
-# But does that mean they are descended from Breccán? Maybe foaf:knows,instead? EPT
+
+<< <#CenélCróchnae>
+        rdfs:comment "Cenél Cróchnae in cethramad prím-aiccme Úa m-Bairrchi. Is fri Ú Breccáin a tóebud." >>
+        rdfs:comment "I'm not sure about this. 'Is fri Ú Breccáin a tóebud' seems to mean literally 'They are near to Uí Breccáin', that is, they are closely related to Uí Breccáin. But does that mean they are descended from Breccán? Maybe foaf:knows,instead?" ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Breccáin-a5bf6e90>
     a foaf:Person;
@@ -1987,7 +1990,9 @@
     owl:sameAs <#Éinne>;
     owl:sameAs <http://example.com/LL/de_genelach_dáil_nia_corbb.trig#Emini>.
 
-# "Émíne" versus "Éinne" could easily be caused by minim confusion. EPT
+<< <#Émíne-faf99e10>
+            rdfs:comment "'Émíne' versus 'Éinne' could easily be caused by minim confusion." >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Góedelán>
     a foaf:Person;
@@ -2118,10 +2123,9 @@
     rel:descendantOf <#Cathair>;
     owl:sameAs <http://example.com/LL/de_genelach_dáil_nia_corbb.trig#Oengusa-bf1c454a>.
 
-# It is not clear who <#Oengusa> is. The last mentioned "Oengus" is
-# Oengus mac Meic Erca, but the list of sons here does not include Eochaid Guinech,
-# who is his son earlier in this section. For now, it seems inconceivable that
-# he wouldn't be a descendant of Cathair Már, in this section of the genealogies. EPT
+<< <#Oengusa>
+            rdfs:comment "It is not clear who <#Oengusa> is. The last mentioned 'Oengus' is Oengus mac Meic Erca, but the list of sons here does not include Eochaid Guinech, who is his son earlier in this section. For now, it seems inconceivable that he wouldn't be a descendant of Cathair Már, in this section of the genealogies." >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Trian>
     a foaf:Person;
@@ -2165,7 +2169,9 @@
     rel:employerOf <#Áed>;
     owl:sameAs <http://example.com/LL/de_genelach_dáil_nia_corbb.trig#Cormaic-a3f93360>.
 
-# Obviously one thinks of Cormac mac Airt, but there is no evidence for this. EPT
+<< <#Chormaic>
+            rdfs:comment "Obviously one thinks of Cormac mac Airt, but there is no evidence for this." >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#FintanMéth>
     a foaf:Person;
@@ -2255,9 +2261,10 @@
     irishRel:populationGroupName "Chenéol Chruaichne";
     rdfs:comment "Úi Gestáin immorro do Chenéol Chruaichne dóib".
 
-# It is not clear what "dóib" ("of them") points to. Úi Gestain? Dál Mesin Corb?
-# Or does it mean "for them", "as far as they are concerned" i.e. just a meaningless
-# emphatic? I have gone for Dál Mesin Corb as the overarching kin-group, for now. EPT
+<< <#ChenéolChruaichne>
+            rdfs:comment "Úi Gestáin immorro do Chenéol Chruaichne dóib" >>
+            rdfs:comment "It is not clear what 'dóib' ('of them') points to. Úi Gestain? Dál Mesin Corb? Or does it mean 'for them', 'as far as they are concerned' i.e. just a meaningless emphatic? I have gone for Dál Mesin Corb as the overarching kin-group, for now. " ;
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ÚiNémáin>
     a irishRel:PopulationGroup;
@@ -2509,11 +2516,9 @@
     owl:sameAs <http://example.com/LL/de_genelach_dáil_nia_corbb.trig#AedaDemnuin>;
     irishRel:ancestorOfGroup <#ÚiMóenaigCoisseScaible>.
 
-# So, above, in para. 222, we read "Rotha m. Óengusa a quo Úi Fétháin i m-Maig
-# Dá Chonn ro bí Áed di muin Chormaic ind ríg". There, I took "di muin Chormaic" to mean
-# "on account of Cormac" (i.e. by order of Cormac). However, here we have an individual called
-# "Áed Demuin", followed by the name "Cormac". Could a scribe have got confused somewhere? If so,
-# where...? EPT
+<< <#ÁedaDemuin>
+            rdfs:comment "So, above, in para. 222, we read 'Rotha m. Óengusa a quo Úi Fétháin i m-Maig Dá Chonn ro bí Áed di muin Chormaic ind ríg'. There, I took 'di muin Chormaic' to mean 'on account of Cormac' (i.e. by order of Cormac). However, here we have an individual called 'Áed Demuin', followed by the name 'Cormac'. Could a scribe have got confused somewhere? If so, where...?" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cormaic-094cdea0>
     a foaf:Person;
@@ -2775,7 +2780,9 @@
     owl:sameAs <http://example.com/LL/de_genelach_dáil_nia_corbb.trig#Cormaic-e1ec9ca7>;
     foaf:knows <#ChomgallBendchuir>.
 
-# gaveLandTo EPT
+<< <#Cormac-96ea6d80>
+            rdfs:comment "gaveLandTo" >>
+            prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Diarmata-a6dac7d0>
     a foaf:Person;

--- a/Rawl_B502/genelach_úa_meic_brócc.trig
+++ b/Rawl_B502/genelach_úa_meic_brócc.trig
@@ -194,7 +194,10 @@
 <#Lappae-8c8e0cc5>
     a foaf:Person;
     irishRel:genName "Lappae".
-# same as <#Lappae> above? - CY
+
+<< <#Lappae-8c8e0cc5>
+        rdfs:comment "same as <#Lappae> above?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Suibne-bd480ae8>
     a foaf:Person;

--- a/Rawl_B502/genelach_úa_raithnen.trig
+++ b/Rawl_B502/genelach_úa_raithnen.trig
@@ -1235,7 +1235,11 @@
     irishRel:genName "Baíthmeic";
     rel:childOf <#Sencháin>;
     owl:sameAs <http://example.com/LL/h_raithnen.trig#Blaithmeic-585337f0>.
-# Recte Blathmac? EPT
+
+<< <#Baíthmeic>
+        irishRel:nomName "Bathmac" >>
+        rdfs:comment "Recte Blathmac?" ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Sencháin>
     a foaf:Person;

--- a/Rawl_B502/haec_sunt_credentium_nomina.trig
+++ b/Rawl_B502/haec_sunt_credentium_nomina.trig
@@ -206,12 +206,18 @@
     irishTitles:coRulerWith <#Cellach>;
     irishTitles:reignLength 16.
 
+<< <#Conall>
+        rdfs:comment "I have searched thoroughly for Conall and Cellach, sons of Máel Coba, in the existing data and cannot find them." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
+
 <#Cellach>
     a irishTitles:Rí;
     irishRel:nomName "Cellach";
     rel:childOf <#MáeliCoba>.
 
-# I have searched thoroughly for Conall and Cellach, sons of Máel Coba, in the existing data and cannot find them. #EPT
+<< <#Cellach>
+        rdfs:comment "I have searched thoroughly for Conall and Cellach, sons of Máel Coba, in the existing data and cannot find them." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#MáeliCoba>
     a foaf:Person;

--- a/Rawl_B502/item_úi_labrada.trig
+++ b/Rawl_B502/item_úi_labrada.trig
@@ -116,7 +116,9 @@
     owl:sameAs <http://example.com/LL/item_h-úi_labrada.trig#Lill-88b47562>;
     rdfs:comment "[secundum alios], Úi Lill".
 
-# <#Lill>, above, is a descendant of Cairthend, not of Coelbad. EPT
+<< <#Lill-75e2def2>
+        rdfs:comment "<#Lill>, above, is a descendant of Cairthend, not of Coelbad." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#DaigBec>
     a foaf:Person;

--- a/Rawl_B502/item_úi_máelhuidir.trig
+++ b/Rawl_B502/item_úi_máelhuidir.trig
@@ -58,7 +58,9 @@
     irishRel:nomName "Cellach";
     rel:childOf <#Dungal>.
 
-# owl:sameAs <http://example.com/LL/dal_corpri_arad.trig#Cathal>? EPT
+<< <#Cellach>
+        rdfs:comment "owl:sameAs <http://example.com/LL/dal_corpri_arad.trig#Cathal>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Gerthide-c0391010>
     a foaf:Person;

--- a/Rawl_B502/item_úi_máelhuidir_2.trig
+++ b/Rawl_B502/item_úi_máelhuidir_2.trig
@@ -20,10 +20,10 @@
     dcterms:format "application/trig" ;
     prov:asDerivedFrom <http://www.ucc.ie/celt/published/G105003/text003.html> .
 
-# This has the same title as a previous section.
-# <http://example.com/Rawl_B502/item_úi_máelhuidir.ttl>
-# This may be a scribal mistake, as Maelodor does not seem to be of relevance
-# here. But it is in the manuscript,so it is being retained. EPT
+<< <> dcterms:title "Item Úi Máel hUidir [2]"@sga >>
+        rdfs:comment "This has the same title as a previous section. <http://example.com/Rawl_B502/item_úi_máelhuidir.ttl> This may be a scribal mistake, as Maelodor does not seem to be of relevance here. But it is in the manuscript,so it is being retained." ;
+        rdfs:seeAlso <http://example.com/Rawl_B502/item_úi_máelhuidir.ttl> ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Branán>
     a foaf:Person;
@@ -92,7 +92,9 @@
     irishRel:nomName "Flann File";
     rel:childOf <#Ma(...)Mod(..)>.
 
-# = Flann File? EPT
+<< <#Flan(.)Fil(.)>
+        rdfs:comment "= Flann File?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Ma(...)Mod(..)>
     a foaf:Person;

--- a/Rawl_B502/item_úi_théig.trig
+++ b/Rawl_B502/item_úi_théig.trig
@@ -267,7 +267,9 @@
     rel:childOf <#ThuathailTigich>;
     irishRel:ancestorOfGroup <#ÚaLugdach>.
 
-# owl:sameAs <#Lugdach>? EPT
+<< <#Lugdach-e14e6030>
+        rdfs:comment "owl:sameAs <#Lugdach>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#ThuathailTigich>
     a foaf:Person;

--- a/Rawl_B502/mínigud_senchais_síl_chuind_inso_sís.trig
+++ b/Rawl_B502/mínigud_senchais_síl_chuind_inso_sís.trig
@@ -68,7 +68,10 @@
     irishRel:nomName "Brigit" ;
     foaf:gender "female" ;
     rdfs:seeAlso <https://www.wikidata.org/entity/Q80979> .
-# is the same as <http://example.com/LL/dal_corpri_arad.trig#Brigit> ? - CY
+
+<< <#Brigit>
+        rdfs:comment "is the same as <http://example.com/LL/dal_corpri_arad.trig#Brigit> ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#naDéisse>
     a irishRel:PopulationGroup ;
@@ -1178,7 +1181,10 @@
 <#CindFáelad>
     a foaf:Person ;
     irishRel:genName "Cind Fáelad" .
-    # Is this the same as the famous one? - CY
+
+<< <#CindFáelad>
+        rdfs:comment "Is this the same as the famous one?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Máelh-Uma>
     a foaf:Person ;

--- a/Rawl_B502/mínugud_senchusa_laigin_and_so_sís.trig
+++ b/Rawl_B502/mínugud_senchusa_laigin_and_so_sís.trig
@@ -119,8 +119,13 @@
     a foaf:Person;
     irishRel:nomName "Ferchertne".
 
-# owl:sameAs <http://example.com/Rawl_B502/senchas_síl_h_ir_fo_h_érind.trig#FerchertneFile>?
-# They are both called Ferchertne and they are both poets - that is all! EPT
+<< <#Ferchertne>
+        rdfs:comment "owl:sameAs <http://example.com/Rawl_B502/senchas_síl_h_ir_fo_h_érind.trig#FerchertneFile>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Ferchertne>
+        rdfs:comment "They are both called Ferchertne and they are both poets - that is all!" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <http://www.vanhamel.nl/codecs/Dind_R%C3%ADg,_r%C3%BAad_T%C3%BAaim_Tenbath>
     prov:wasAttributedTo <#Ferchertne>.
@@ -290,9 +295,10 @@
 <#Senchán-06232f40>
     a foaf:Person;
     irishRel:nomName "Senchán".
-# owl:sameAs <#Senchán>? No direct evidence for them being the same but they are both
-# ascribed genealogical poetry in this section of the text without any effort made to
-# distinguish them? EPT
+
+<< <#Senchán-06232f40>
+        rdfs:comment "owl:sameAs <#Senchán>? No direct evidence for them being the same but they are both ascribed genealogical poetry in this section of the text without any effort made to distinguish them?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Cethri_mc_la_Sétna_Sithbacc>
     dcterms:title "Cethri mc la Sétna Sithbacc"@sga;
@@ -1212,7 +1218,10 @@
     irishRel:populationGroupName "Dál Cairpri Loingsig Bic";
     rdfs:comment "in cethramad prím-slonnud Lagen. La h-Aradu Cliach atát.".
 
-# Are the "Aradu Cliach" a populationGroup? EPT
+<< <#DálCairpriLoingsigBic>
+        rdfs:comment "in cethramad prím-slonnud Lagen. La h-Aradu Cliach atát." >>
+        rdfs:comment "Are the 'Aradu Cliach' a populationGroup?" ;
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Corpri>
     a foaf:Person;

--- a/Rawl_B502/nidu_dír_dermait.trig
+++ b/Rawl_B502/nidu_dír_dermait.trig
@@ -232,7 +232,9 @@
     owl:sameAs <http://example.com/Rawl_B502/de_regibus_lagenorum.trig#NadBuidb>;
     owl:sameAs <http://example.com/LL/genelach_h_n-enechglais.trig#NadBuidb>.
 
-# Or owl:sameAs <http://example.com/LL/dal_corpri_arad.trig#NadBuidb-fb5b07ec>?
+<< <#NadBuidb>
+        rdfs:comment "Or owl:sameAs <http://example.com/LL/dal_corpri_arad.trig#NadBuidb-fb5b07ec>?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#EircBuadaig>
     a irishTitle:Rí ;

--- a/Rawl_B502/nunc_dál_carpri_dítha.trig
+++ b/Rawl_B502/nunc_dál_carpri_dítha.trig
@@ -71,7 +71,10 @@
     irishRel:nomName "M.scuire";
     irishRel:genName "M.scuire";
     rel:childOf <#Dalláin>.
-# second letter illegible in ms. EPT
+
+<< <#M.scuire>
+        rdfs:comment "second letter illegible in ms." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Dalláin>
     a foaf:Person;

--- a/Rawl_B502/senchas_síl_h_ir_fo_h_érind.trig
+++ b/Rawl_B502/senchas_síl_h_ir_fo_h_érind.trig
@@ -467,7 +467,10 @@
     a foaf:Person;
     irishRel:nomName "Let";
     rel:childOf <#Rudraigi-491a5513>.
-    # see <#RudraigeLett> in LL as there seems to be some confusion here CY
+
+<< <#Let>
+        rdfs:comment "see <#RudraigeLett> in LL as there seems to be some confusion here " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#Rudraigi-491a5513>
     owl:sameAs <#Rudraigi>.
@@ -771,8 +774,14 @@
     foaf:gender "female";
     irishRel:nomName "Macha" ;
     irishTitle:succeededBy <#Rudraige-d760a886>.
-# sameAs http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#CauscraidMendMacha ? CY
-# No - Macha is a woman. This is described in more detail elsewhere (see Rawl_B502/_92.ttl). EPT
+
+<< <#Macha>
+        rdfs:comment "sameAs http://example.com/LL/clanna_ébir_i_l-leith_chuind.trig#CauscraidMendMacha ?" >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
+
+<< <#Macha>
+        rdfs:comment "No - Macha is a woman. This is described in more detail elsewhere (see Rawl_B502/_92.ttl)." >>
+        prov:wasAttributedTo <https://orcid.org/0000-0003-2819-5519> .
 
 <#Rudraige-d760a886>
     a irishTitle:Rí ;

--- a/Rawl_B502/úi_chummaind.trig
+++ b/Rawl_B502/úi_chummaind.trig
@@ -63,7 +63,10 @@
     irishRel:genName "Linge" ;
     irishRel:genName "Luigne" ;
     irishRel:numChild 2 .
-# sameAs De Úib Angáin Linge Labar ? - CY
+
+<< <#Linge>
+        rdfs:comment "sameAs De Úib Angáin Linge Labar ? " >>
+        prov:wasAttributedTo <https://orcid.org/0000-0002-7241-3264> .
 
 <#LingeDub>
     a foaf:Person ;

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,9 +1,8 @@
 steps:
-  - name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', 'gs://irish-gen-build-dependencies/apache-jena-3.17.0.tar.gz', '.']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/irish-gen-build', '.']
+    args: ['pull', '-t', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', '.']
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build', 'bash']
-    env: ['IRISH_GEN_HOME=/workspace']
+    args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', 'bash']
 
+images:
+  - 'gcr.io/$PROJECT_ID/irish-gen-build'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['pull', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', '.']
+    args: ['pull', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17']
   - name: 'gcr.io/cloud-builders/docker'
     args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', 'bash']
 

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -3,6 +3,3 @@ steps:
     args: ['pull', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17']
   - name: 'gcr.io/cloud-builders/docker'
     args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', 'bash']
-
-images:
-  - 'gcr.io/$PROJECT_ID/irish-gen-build'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', 'gs://irish-gen-build-dependencies/apache-jena-3.16.0.tar.gz', '.']
+    args: ['cp', 'gs://irish-gen-build-dependencies/apache-jena-3.17.0.tar.gz', '.']
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'gcr.io/$PROJECT_ID/irish-gen-build', '.']
   - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -7,5 +7,3 @@ steps:
     args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build', 'bash']
     env: ['IRISH_GEN_HOME=/workspace']
 
-images:
-  - 'gcr.io/$PROJECT_ID/irish-gen-build'

--- a/cloudbuild.yml
+++ b/cloudbuild.yml
@@ -1,6 +1,6 @@
 steps:
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['pull', '-t', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', '.']
+    args: ['pull', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', '.']
   - name: 'gcr.io/cloud-builders/docker'
     args: ['run', '--volume', '/workspace:/workspace', 'gcr.io/$PROJECT_ID/irish-gen-build:apache-jena-3-17', 'bash']
 

--- a/utils/check_file_syntax.sh
+++ b/utils/check_file_syntax.sh
@@ -12,7 +12,7 @@ then
     exit 1
 fi
 
-find $IRISH_GEN_HOME  \( -name '*.trig' -o -name '*.ttl' \) -print0 | xargs -0 $JENA_HOME/bin/riot --validate --verbose | egrep -B 1 "WARN|ERROR"
+find $IRISH_GEN_HOME  \( -name '*.trig' -o -name '*.ttl' \) -print0 | xargs -0 $JENA_HOME/bin/riot --validate --verbose 2>&1 | egrep -B 1 "WARN|ERROR"
 
 # if grep does not match something, it will set $? to 1 but
 # in our case if it does not find an ERROR or WARN then that


### PR DESCRIPTION
Moved curator comments to a format that is searchable in SPARQL* and attributable to a curator.  Not all comments were converted so if there are more found, they can be converted at the time.  Additionally, moved to a new container format for format checking on GCP.